### PR TITLE
Fix ../lib/ path rewrite to cover app.js, not just index.html

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -34,7 +34,7 @@ jobs:
           mkdir -p _site
           cp -r example/. _site/
           cp -r lib _site/lib
-          sed -i 's#\.\./lib/#lib/#g' _site/index.html
+          find _site -maxdepth 1 -type f \( -name '*.html' -o -name '*.js' \) -exec sed -i 's#\.\./lib/#lib/#g' {} +
       - uses: actions/upload-pages-artifact@v5.0.0
 
   deploy:


### PR DESCRIPTION
The Pages deploy workflow's path-rewrite step only touched _site/index.html, missing app.js's runtime fetch of the mock CSV data (../lib/mock-data/concept2-result-44214428.csv), which 404'd on the live site. Broadens the sed to every HTML/JS file in _site/ so this doesn't recur if more files reference lib/ the same way.