### PR TITLE
Rename strokeCalories to strokeCaloricBurnRate and wire calPerHour through mock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Concept2's copyrighted CSAFE spec, fetched locally for reference — see
+# README.md "Reference: the CSAFE spec" for the source URL and how to
+# regenerate it. Not redistributed since this repo is public.
+docs/csafe-spec.pdf
+docs/csafe-spec.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,17 +99,21 @@ matters — no module system):
    sample is
    `{ t, distance, pace, watts, calPerHour, strokeRate, heartRate }` (any field
    but `t` may be `undefined`); `_toBleGeneralStatus`/`_toBleAdditionalStatus`/
-   `_toHid` map it to the same field keys `pm5fields` already defines for the
-   real transports, omitting keys whose value is `undefined` so nothing
-   renders for missing HR/stroke-rate readings. For BLE, each replay tick
-   dispatches **two** `multiplexed-information` events — one shaped like real
-   general-status (`elapsedTime`, `distance`), one like additional-status
-   (`elapsedTime`, `currentPace`, `averagePower`, `strokeRate`, `heartRate`) —
-   mirroring how real hardware demuxes distinct sub-messages onto that one
-   event type rather than bundling every field into a single dispatch (see
-   Protocol notes). HID stays a single `workout` dispatch per tick, since
-   that's how the real USB protocol actually behaves (one polled frame, many
-   chained CSAFE commands, one combined response).
+   `_toBleAdditionalStrokeData`/`_toHid` map it to the same field keys
+   `pm5fields` already defines for the real transports, omitting keys whose
+   value is `undefined` so nothing renders for missing HR/stroke-rate/
+   caloric-burn-rate readings. For BLE, each replay tick dispatches **three**
+   `multiplexed-information` events — one shaped like real general-status
+   (`elapsedTime`, `distance`), one like additional-status (`elapsedTime`,
+   `currentPace`, `averagePower`, `strokeRate`, `heartRate`), one like
+   additional-stroke-data (`elapsedTime`, `strokeCaloricBurnRate`) — mirroring
+   how real hardware demuxes distinct sub-messages onto that one event type
+   rather than bundling every field into a single dispatch (see Protocol
+   notes). HID stays a single `workout` dispatch per tick, since that's how
+   the real USB protocol actually behaves (one polled frame, many chained
+   CSAFE commands, one combined response); HID has no caloric-burn-rate
+   field, only a cumulative `calories` total, so `calPerHour` goes unmapped
+   there.
    `MESSAGE_EVENTS` is set **per instance** (not static, unlike `PM5`/`PM5HID`)
    since its shape depends on `emulate` — see the app.js note below.
    - **`lib/mock-data/csv-source.js`** — the first (and currently only) sample
@@ -199,9 +203,9 @@ project — feeding the same seam.
   (transport-shaped, protocol-agnostic) and the sample source (currently CSV,
   future Logbook API): they only agree on the normalized sample shape. On the
   BLE side it also mirrors the real demux split (general-status vs
-  additional-status) rather than bundling every field into one event — worth
-  checking again if a third BLE sub-message type (e.g. stroke-data) ever needs
-  emulating.
+  additional-status vs additional-stroke-data) rather than bundling every
+  field into one event — worth checking again if another BLE sub-message type
+  ever needs emulating.
 - The transports report overlapping data under **different key names** (e.g.
   BLE `strokeRate` vs HID `cadence`, BLE `currentPace`/`averagePace` vs HID
   `pace`), so most keys coexist without collision. Only the five shared keys

--- a/README.md
+++ b/README.md
@@ -171,6 +171,34 @@ product repo meant to receive ongoing updates, use a git submodule instead —
    in library updates later.
 5. Commit and push.
 
+## Reference: the CSAFE spec
+
+`lib/pm5-hid.js` (and `lib/pm5-ble.js`'s cross-reference comments) implement
+commands from Concept2's own protocol document, [Concept2 PM CSAFE
+Communication Definition][csafe-spec] (PDF, © Concept2 — publicly downloadable
+for third-party developers, not redistributed here).
+
+It's 173 pages, so re-fetching and re-reading it from scratch each time it's
+needed is wasteful. Instead, download it once and convert it to
+`docs/csafe-spec.txt` for local reference — both `docs/csafe-spec.pdf` and
+`docs/csafe-spec.txt` are git-ignored (not committed, since this repo is
+public) but persist on disk for reuse in later sessions:
+
+```
+curl -sL -o docs/csafe-spec.pdf "https://cms.concept2.com/sites/default/files/2026-03/Concept2%20PM%20CSAFE%20Communication%20Definition.pdf"
+pip install --user pypdf
+python3 -c "
+from pypdf import PdfReader
+r = PdfReader('docs/csafe-spec.pdf')
+with open('docs/csafe-spec.txt', 'w') as f:
+    for i, page in enumerate(r.pages):
+        f.write(f'\n\n===== Page {i+1} =====\n\n')
+        f.write(page.extract_text() or '')
+"
+```
+
+[csafe-spec]: https://cms.concept2.com/sites/default/files/2026-03/Concept2%20PM%20CSAFE%20Communication%20Definition.pdf
+
 ## Tests
 
 The pure `lib/` modules (field/formatter maps, CSV parsing, sample mapping)

--- a/lib/pm5-ble.js
+++ b/lib/pm5-ble.js
@@ -477,7 +477,7 @@ class PM5 extends EventTarget {
      *
      * elapsedTime          = N/A
      * strokePower          = CSAFE_PM_GET_STROKE_POWER
-     * strokeCalories       = CSAFE_PM_GET_STROKE_CALORICBURNRATE
+     * strokeCaloricBurnRate= CSAFE_PM_GET_STROKE_CALORICBURNRATE
      * strokeCount          = CSAFE_PM_GET_STROKESTATS
      * projectedWorkTime    = N/A
      * projectedWorkDistance= N/A
@@ -490,7 +490,7 @@ class PM5 extends EventTarget {
         const r = {
             elapsedTime:          (v[o+0] + (v[o+1] << 8) + (v[o+2] << 16)) * 0.01,
             strokePower:          (v[o+3] + (v[o+4] << 8)),
-            strokeCalories:       (v[o+5] + (v[o+6] << 8)),
+            strokeCaloricBurnRate:(v[o+5] + (v[o+6] << 8)),
             strokeCount:          (v[o+7] + (v[o+8] << 8)),
             projectedWorkTime:    (v[o+9] + (v[o+10] << 8) + (v[o+11] << 16)),
             projectedWorkDistance:(v[o+12] + (v[o+13] << 8) + (v[o+14] << 16)),

--- a/lib/pm5-fields.js
+++ b/lib/pm5-fields.js
@@ -14,6 +14,7 @@ const pm5printables = {
     spm:              n => n + ' spm',
     watts:            n => n.toFixed().toLocaleString() + 'W',
     calories:         n => n.toLocaleString() + 'cals',
+    calPerHour:       n => n.toLocaleString() + 'cal/hr',
     metres_fixed:     n => n.toFixed().toLocaleString() + 'm',
     wattMinutes:      n => n.toLocaleString() + 'Wm',
     splitIntervalType: n => n.toString(),
@@ -318,9 +319,9 @@ const pm5fields = {
         label: 'Stroke Power',
         printable: pm5printables.watts,
     },
-    strokeCalories: {
-        label: 'Stroke Calories',
-        printable: pm5printables.calories,
+    strokeCaloricBurnRate: {
+        label: 'Stroke Caloric Burn Rate',
+        printable: pm5printables.calPerHour,
     },
     projectedWorkTime: {
         label: 'Projected Work Time',

--- a/lib/pm5-hid.js
+++ b/lib/pm5-hid.js
@@ -230,6 +230,14 @@ class PM5HID extends EventTarget {
         };
     }
 
+    // TODO: no CSAFE opcode exists for BLE's strokeCaloricBurnRate (cal/hr) —
+    // confirmed against the Concept2 PM CSAFE Communication Definition, whose
+    // command tables have no such command despite footnoting it against the
+    // BLE additional-stroke-data characteristic. The spec's own Pace
+    // Conversions appendix gives a derivation from pace instead
+    // (Calories/Hr = ((2.8 / pace^3) * (4.0 * 0.8604)) + 300, pace in
+    // sec/meter) — worth wiring up from the existing `pace` reading, but
+    // needs confirming against real hardware first.
     #extractStroke(resp) {
         const { cmds } = resp;
         const get = k => cmds.get(k) ?? [];

--- a/lib/pm5-mock.js
+++ b/lib/pm5-mock.js
@@ -86,11 +86,12 @@ class PM5Mock extends EventTarget {
         }
         // Real BLE hardware demuxes several distinct sub-messages onto the
         // one 'multiplexed-information' event type, each carrying only its
-        // own fields (see pm5-ble.js _cbGeneralStatus/_cbAdditionalStatus).
-        // Mirror that here with two narrower dispatches instead of one
-        // event bundling every field.
+        // own fields (see pm5-ble.js _cbGeneralStatus/_cbAdditionalStatus/
+        // _cbAdditionalStrokeData). Mirror that here with narrower dispatches
+        // instead of one event bundling every field.
         this.#dispatch('multiplexed-information', PM5Mock._toBleGeneralStatus(sample));
         this.#dispatch('multiplexed-information', PM5Mock._toBleAdditionalStatus(sample));
+        this.#dispatch('multiplexed-information', PM5Mock._toBleAdditionalStrokeData(sample));
     }
 
     #dispatch(type, data = null) {
@@ -121,6 +122,14 @@ class PM5Mock extends EventTarget {
         if (s.watts      !== undefined) data.averagePower = s.watts;
         if (s.strokeRate !== undefined) data.strokeRate   = s.strokeRate;
         if (s.heartRate  !== undefined) data.heartRate    = s.heartRate;
+        return data;
+    }
+
+    // Mirrors real additional-stroke-data: elapsedTime + stroke caloric burn rate.
+    static _toBleAdditionalStrokeData(s) {
+        const data = {};
+        if (s.t          !== undefined) data.elapsedTime           = s.t;
+        if (s.calPerHour !== undefined) data.strokeCaloricBurnRate = s.calPerHour;
         return data;
     }
 

--- a/test/pm5-mock.test.mjs
+++ b/test/pm5-mock.test.mjs
@@ -56,6 +56,15 @@ test('_toBleGeneralStatus and _toBleAdditionalStatus never overlap except elapse
     assert.deepEqual(overlap, ['elapsedTime']);
 });
 
+test('_toBleAdditionalStrokeData omits undefined fields and only emits known pm5fields keys', () => {
+    const withRate    = PM5Mock._toBleAdditionalStrokeData({ t: 10, calPerHour: 576 });
+    const withoutRate = PM5Mock._toBleAdditionalStrokeData({ t: 0.7, calPerHour: undefined });
+
+    assert.deepEqual(withRate, { elapsedTime: 10, strokeCaloricBurnRate: 576 });
+    assert.deepEqual(withoutRate, { elapsedTime: 0.7 });
+    for (const k of Object.keys(withRate)) assert.ok(k in pm5fields, `missing key ${k}`);
+});
+
 test('_toHid omits undefined fields and only emits known pm5fields keys', () => {
     const withHr    = PM5Mock._toHid({ t: 10, distance: 20, pace: 150, watts: 100, strokeRate: 24, heartRate: 142 });
     const withoutHr = PM5Mock._toHid({ t: 0.7, distance: 2.4, pace: 163.3, watts: 80, strokeRate: undefined, heartRate: undefined });


### PR DESCRIPTION
The field name didn't match its CSAFE command (CSAFE_PM_GET_STROKE_
CALORICBURNRATE, a cal/hr rate, not a total), so rename it and give it
its own printable instead of reusing the cumulative-calories formatter.
Mock now dispatches a third BLE sub-message mirroring real hardware's
additional-stroke-data characteristic, so the CSV's calPerHour actually
reaches the UI. HID has no equivalent CSAFE command (confirmed against
the spec, now vendored locally as docs/csafe-spec.{pdf,txt}, gitignored
since this repo is public) — left unmapped with a TODO, pending
confirmation against real hardware.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
