### PR TITLE
Let PM5Mock replay raw JSON events, not just reduced CSV samples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ lib/                  reusable, DOM-free protocol/data code
   pm5-fields.js
   mock-data/
     csv-source.js
+    events-source.js
     concept2-result-44214428.csv
 example/               the demo app (all DOM-touching code)
   index.html
@@ -91,41 +92,63 @@ matters — no module system):
    tick, a full workout frame every 5th tick). Dispatches its data as `workout`
    and `stroke` events. Also zero DOM dependencies.
 3. **`lib/pm5-mock.js`** — `PM5Mock`, an `EventTarget` subclass replaying a
-   normalized sample array as either BLE- or HID-shaped events (`emulate: 'ble'
-   | 'hid'`, default `'ble'`). It has **no knowledge of where samples come
-   from** — the constructor takes either a pre-loaded `samples` array or an
-   async `loadSamples()` — so it stays a pure replay engine (chained
-   `setTimeout`, honoring real inter-sample gaps scaled by a `speed`
-   multiplier, default `1` = real-time; optional `loop`). `setSpeed(n)` adjusts
-   it live, taking effect from the next scheduled sample onward. A normalized
-   sample is
-   `{ t, distance, pace, watts, calPerHour, strokeRate, heartRate }` (any field
-   but `t` may be `undefined`); `_toBleGeneralStatus`/`_toBleAdditionalStatus`/
-   `_toBleAdditionalStrokeData`/`_toHid` map it to the same field keys
-   `pm5fields` already defines for the real transports, omitting keys whose
-   value is `undefined` so nothing renders for missing HR/stroke-rate/
-   caloric-burn-rate readings. For BLE, each replay tick dispatches **three**
-   `multiplexed-information` events — one shaped like real general-status
-   (`elapsedTime`, `distance`), one like additional-status (`elapsedTime`,
-   `currentPace`, `averagePower`, `strokeRate`, `heartRate`), one like
-   additional-stroke-data (`elapsedTime`, `strokeCaloricBurnRate`) — mirroring
-   how real hardware demuxes distinct sub-messages onto that one event type
-   rather than bundling every field into a single dispatch (see Protocol
-   notes). HID stays a single `workout` dispatch per tick, since that's how
-   the real USB protocol actually behaves (one polled frame, many chained
-   CSAFE commands, one combined response); HID has no caloric-burn-rate
-   field, only a cumulative `calories` total, so `calPerHour` goes unmapped
-   there.
-   `MESSAGE_EVENTS` is set **per instance** (not static, unlike `PM5`/`PM5HID`)
-   since its shape depends on `emulate` — see the app.js note below.
-   - **`lib/mock-data/csv-source.js`** — the first (and currently only) sample
-     source: `parseCsv(text)` parses a Concept2 workout CSV export into the
-     normalized sample array, and `loadFromUrl(url)` fetches + parses it. A
-     future source (e.g. the Concept2 Logbook API, a separate future project)
-     would be a sibling module producing the same array shape and passed to
-     `PM5Mock` via `loadSamples`; no changes to `pm5-mock.js` needed. A
-     synthetic (non-recorded) generator was deliberately skipped — YAGNI, add
-     one behind the same `loadSamples` seam if/when needed.
+   flat, already transport-shaped raw event list — `[{ t, type, data }]`, `t`
+   = elapsed ms since replay start — through one chained-`setTimeout` engine
+   (`#scheduleNext`), honoring real inter-event gaps scaled by a `speed`
+   multiplier (default `1` = real-time; optional `loop`). `setSpeed(n)`
+   adjusts it live, taking effect from the next scheduled event onward. It
+   has **no knowledge of where that list comes from** — two mutually
+   exclusive ways in:
+   - **Reduced samples** (`samples`/`loadSamples`, pre-loaded array or async
+     loader) — `{ t, distance, pace, watts, calPerHour, strokeRate,
+     heartRate }` (any field but `t` may be `undefined`), synthesized into
+     the raw event list by `_toRawEvents(samples, emulate)` (`emulate:
+     'ble' | 'hid'`, default `'ble'`, since samples carry no transport info
+     of their own). `_toBleGeneralStatus`/`_toBleAdditionalStatus`/
+     `_toBleAdditionalStrokeData`/`_toHid` map a sample to the same field
+     keys `pm5fields` defines for the real transports, omitting keys whose
+     value is `undefined` so nothing renders for missing HR/stroke-rate/
+     caloric-burn-rate readings. For BLE, each sample synthesizes **three**
+     `multiplexed-information` raw events — general-status (`elapsedTime`,
+     `distance`), additional-status (`elapsedTime`, `currentPace`,
+     `averagePower`, `strokeRate`, `heartRate`), additional-stroke-data
+     (`elapsedTime`, `strokeCaloricBurnRate`) — mirroring how real hardware
+     demuxes distinct sub-messages onto that one event type rather than
+     bundling every field into a single dispatch (see Protocol notes). HID
+     synthesizes a single `workout` event per sample, since that's how the
+     real USB protocol actually behaves (one polled frame, many chained
+     CSAFE commands, one combined response); HID has no caloric-burn-rate
+     field, only a cumulative `calories` total, so `calPerHour` goes
+     unmapped there.
+   - **Raw events** (`events`/`loadEvents`, same pre-loaded-or-async
+     shape) — used verbatim, no synthesis, since each entry already carries
+     the real dispatched type/data. This is what a full-fidelity recording
+     (every field a real transport actually reported, not just the seven
+     reduced-sample fields) replays through.
+
+   `MESSAGE_EVENTS` is set **per instance** (not static, unlike `PM5`/
+   `PM5HID`) — derived as `[...new Set(rawEvents.map(e => e.type))]` once
+   the data is in hand, so it always reflects what's actually going to be
+   dispatched rather than being hardcoded from `emulate`. Set synchronously
+   in the constructor when `samples`/`events` are given directly (tests rely
+   on this), or once `connect()` resolves an async loader — always before
+   `connected` is dispatched, which is the only point app.js reads it (see
+   the app.js note below).
+   - **`lib/mock-data/csv-source.js`** — parses a Concept2 workout CSV
+     export into the reduced sample array: `parseCsv(text)`, plus
+     `loadFromUrl(url)`/`loadFromFile(file)` wrappers.
+   - **`lib/mock-data/events-source.js`** — parses our own JSON event
+     export (see `ergarcade/recorder`'s `events.js`) into the raw event
+     list: `parseJson(text)` relativizes the recorded wall-clock `t` (each
+     event's `Date.now()` at capture) to start at 0, matching the
+     elapsed-ms-since-start baseline `_toRawEvents` also produces, plus a
+     `loadFromFile(file)` wrapper.
+   - A future sample source (e.g. the Concept2 Logbook API, a separate
+     future project) would be a sibling module to `csv-source.js` producing
+     the same reduced-sample array and passed to `PM5Mock` via
+     `loadSamples`; no changes to `pm5-mock.js` needed. A synthetic
+     (non-recorded) generator was deliberately skipped — YAGNI, add one
+     behind the same `loadSamples`/`loadEvents` seam if/when needed.
 4. **`lib/pm5-fields.js`** — pure data/formatting layer, no DOM or transport
    code. `pm5printables` holds formatter functions (units, enums-to-labels, time
    formatting). `pm5fields` maps each data key (from any transport) to a
@@ -178,12 +201,18 @@ needed.
 
 ### Adding another mock data source
 
-Write a sibling module to `lib/mock-data/csv-source.js` that produces the same
-normalized sample array (`{ t, distance, pace, watts, calPerHour, strokeRate,
-heartRate }`), then pass it to `PM5Mock` via `loadSamples` (or pre-load it and
-pass `samples` directly). No changes to `pm5-mock.js` needed. The Concept2
-Logbook API (OAuth) is the planned faithful future source — a separate future
-project — feeding the same seam.
+For a reduced-sample source: write a sibling module to
+`lib/mock-data/csv-source.js` that produces the same normalized sample array
+(`{ t, distance, pace, watts, calPerHour, strokeRate, heartRate }`), then
+pass it to `PM5Mock` via `loadSamples` (or pre-load it and pass `samples`
+directly). No changes to `pm5-mock.js` needed. The Concept2 Logbook API
+(OAuth) is the planned faithful future source — a separate future project —
+feeding the same seam.
+
+For a full-fidelity source: write a sibling module to
+`lib/mock-data/events-source.js` that produces the same raw event array
+(`[{ t, type, data }]`, `t` relativized to start at 0), then pass it via
+`loadEvents`/`events`. No changes to `pm5-mock.js` needed here either.
 
 ## Protocol notes worth knowing before touching the transport classes
 
@@ -202,12 +231,14 @@ project — feeding the same seam.
   `SETUSERCFG1` (0x1a). See the Concept2 PM CSAFE Communication Definition (SDK).
 - **Mock (`pm5-mock.js`)**: not a protocol at all — it's a data replay engine.
   The interesting design point is the separation between the replay engine
-  (transport-shaped, protocol-agnostic) and the sample source (currently CSV,
-  future Logbook API): they only agree on the normalized sample shape. On the
-  BLE side it also mirrors the real demux split (general-status vs
-  additional-status vs additional-stroke-data) rather than bundling every
-  field into one event — worth checking again if another BLE sub-message type
-  ever needs emulating.
+  (a single flat raw-event list, transport/source-agnostic) and where that
+  list comes from: either synthesized from reduced samples (CSV today,
+  future Logbook API) via `_toRawEvents`, or read verbatim from a
+  full-fidelity JSON recording (`events-source.js`) that already carries
+  real type/data. On the BLE synthesis side it also mirrors the real demux
+  split (general-status vs additional-status vs additional-stroke-data)
+  rather than bundling every field into one event — worth checking again if
+  another BLE sub-message type ever needs emulating.
 - The transports report overlapping data under **different key names** (e.g.
   BLE `strokeRate` vs HID `cadence`, BLE `currentPace`/`averagePace` vs HID
   `pace`), so most keys coexist without collision. Only the five shared keys

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ monitor.addEventListener('disconnected', () => { /* link dropped */ });
 await monitor.connect();
 
 // MESSAGE_EVENTS lists the data event types this transport emits. PM5/PM5HID
-// expose it as a static; PM5Mock sets it per instance (its shape depends on
-// the `emulate` option), so check the instance first:
+// expose it as a static; PM5Mock sets it per instance, derived from whatever
+// it's actually replaying, so check the instance first:
 const events = monitor.MESSAGE_EVENTS ?? monitor.constructor.MESSAGE_EVENTS;
 for (const type of events) {
     monitor.addEventListener(type, event => console.log(event.type, event.data));
@@ -123,10 +123,30 @@ shared verbatim across transports.
 
 ## Developing without hardware: `PM5Mock`
 
+`PM5Mock` replays either of two shapes, and has no knowledge of where either
+comes from:
+
+- **Reduced samples** (`samples`/`loadSamples`) — `{ t, distance, pace,
+  watts, calPerHour, strokeRate, heartRate }`, synthesized into BLE- or
+  HID-shaped events per the `emulate` option since samples carry no
+  type/transport info of their own. The shipped source is
+  `lib/mock-data/csv-source.js`, which parses a real Concept2 workout CSV
+  export (`lib/mock-data/concept2-result-44214428.csv`, or any Concept2
+  Logbook CSV via `parseCsv`/`loadFromFile`/`loadFromUrl`) into that shape.
+- **Raw events** (`events`/`loadEvents`) — `[{ t, type, data }]`, replayed
+  verbatim with no synthesis, since each entry already carries the real
+  dispatched type/data (higher fidelity than the reduced samples — every
+  field the original transport reported, not just the seven above).
+  `lib/mock-data/events-source.js`'s `parseJson`/`loadFromFile` reads this
+  shape from a JSON export (see `ergarcade/recorder`'s Export Events).
+  `emulate` is irrelevant here — `MESSAGE_EVENTS` is derived from whatever
+  types the file actually contains.
+
 ```js
 const monitor = new PM5Mock({
     loadSamples: () => csvSource.loadFromUrl('mock-data/concept2-result-44214428.csv'),
-    emulate: 'ble',   // or 'hid' — which event shape to emit
+    // or: loadEvents: () => eventsSource.loadFromFile(uploadedFile),
+    emulate: 'ble',   // or 'hid' — which event shape to synthesize (samples only)
     speed: 1,         // wall-clock multiplier (default 1 = real-time)
     loop: true,       // restart at the end
 });
@@ -134,13 +154,9 @@ const monitor = new PM5Mock({
 monitor.setSpeed(8);  // adjust live; takes effect from the next sample onward
 ```
 
-`PM5Mock` has no knowledge of where samples come from — pass a pre-loaded
-`samples` array, or an async `loadSamples()`. The only source shipped today is
-`lib/mock-data/csv-source.js`, which parses a real Concept2 workout CSV export
-(`lib/mock-data/concept2-result-44214428.csv`) into the normalized sample shape
-`PM5Mock` replays: `{ t, distance, pace, watts, calPerHour, strokeRate,
-heartRate }`. A future source (e.g. the Concept2 Logbook API) would be a
-sibling module producing the same shape — no changes to `pm5-mock.js` needed.
+A future sample source (e.g. the Concept2 Logbook API) would be a sibling
+module to `csv-source.js` producing the same reduced-sample shape — no
+changes to `pm5-mock.js` needed either way.
 
 ## Setting up a new ergarcade product repo
 
@@ -196,8 +212,9 @@ with open('docs/csafe-spec.txt', 'w') as f:
 
 ## Tests
 
-The pure `lib/` modules (field/formatter maps, CSV parsing, sample mapping)
-have node tests, no browser or hardware required:
+The pure `lib/` modules (field/formatter maps, CSV/JSON parsing, sample
+mapping, and `PM5Mock`'s replay engine itself, driven end-to-end with real
+timers) have node tests, no browser or hardware required:
 
 ```
 node --test

--- a/lib/mock-data/csv-source.js
+++ b/lib/mock-data/csv-source.js
@@ -30,6 +30,10 @@ const csvSource = {
         const text = await (await fetch(url)).text();
         return csvSource.parseCsv(text);
     },
+
+    async loadFromFile(file) {
+        return csvSource.parseCsv(await file.text());
+    },
 };
 
 // ponytail: export shim so test/ can import parseCsv under node; a no-op in

--- a/lib/mock-data/events-source.js
+++ b/lib/mock-data/events-source.js
@@ -1,0 +1,27 @@
+// A mock data source for PM5Mock: parses our own JSON event export (see the
+// `recorder` app's events.js) into the raw [{t, type, data}] list PM5Mock
+// replays verbatim via its `events`/`loadEvents` option -- no synthesis,
+// since each entry already carries the real dispatched type/data.
+//
+// Recorded `t` is wall-clock Date.now() at capture time; PM5Mock's replay
+// engine schedules from an elapsed-ms-since-start baseline (the same
+// coordinate system csv-source.js's samples end up in via `t * 1000`), so
+// it's relativized here to start at 0.
+
+const eventsSource = {
+    parseJson(text) {
+        const events = JSON.parse(text);
+        const t0 = events[0]?.t ?? 0;
+        return events.map(e => ({ ...e, t: e.t - t0 }));
+    },
+
+    async loadFromFile(file) {
+        return eventsSource.parseJson(await file.text());
+    },
+};
+
+// ponytail: export shim so test/ can import parseJson under node; a no-op in
+// the browser (no `module`).
+if (typeof module !== 'undefined') {
+    module.exports = { eventsSource };
+}

--- a/lib/pm5-mock.js
+++ b/lib/pm5-mock.js
@@ -1,42 +1,48 @@
 class PM5Mock extends EventTarget {
 
-    // Data-event types app.js subscribes to for this transport. Set per
-    // instance (not static) since the shape depends on the `emulate` option;
-    // app.js reads `monitor.MESSAGE_EVENTS ?? monitor.constructor.MESSAGE_EVENTS`.
-    static MESSAGE_EVENTS_BLE = ['multiplexed-information'];
-    static MESSAGE_EVENTS_HID = ['workout', 'stroke'];
-
-    #samples;
-    #loadSamples;
-    #emulate;
+    #rawEvents; // flat [{t, type, data}], t = elapsed ms since replay start
+    #load;      // async () => that same shape
     #speed;
     #loop;
     #timer     = null;
     #connected = false;
 
-    // `samples` (pre-loaded array) or `loadSamples` (async () => samples[])
-    // are the only two ways in: PM5Mock has no knowledge of where samples
-    // come from. Each sample is { t, distance, pace, watts, calPerHour,
-    // strokeRate, heartRate } (any field but `t` may be undefined). CSV
-    // replay is one source, implemented in mock-data/csv-source.js; a future
-    // Concept2 Logbook API source would be a sibling module producing the
-    // same shape, with no changes needed here.
-    constructor({ samples, loadSamples, emulate = 'ble', speed = 1, loop = false } = {}) {
+    // Two ways in, mutually exclusive:
+    //  - `samples`/`loadSamples`: the reduced sample shape
+    //    ({ t, distance, pace, watts, calPerHour, strokeRate, heartRate }),
+    //    synthesized into transport-shaped raw events via `_toRawEvents`
+    //    (using `emulate`) since samples carry no type/transport info of
+    //    their own. CSV replay is one source, implemented in
+    //    mock-data/csv-source.js.
+    //  - `events`/`loadEvents`: already-real raw events (our own JSON
+    //    export format, mock-data/events-source.js) -- replayed verbatim,
+    //    no synthesis, since they already carry the right type/data.
+    // Either pre-loaded or an async loader; PM5Mock has no knowledge of
+    // where either comes from. `MESSAGE_EVENTS` is set as soon as data is
+    // in hand -- synchronously here if given directly, or once `connect()`
+    // resolves the loader -- always before `connected` is dispatched.
+    constructor({ samples, loadSamples, events, loadEvents, emulate = 'ble', speed = 1, loop = false } = {}) {
         super();
-        this.#samples     = samples ?? null;
-        this.#loadSamples = loadSamples;
-        this.#emulate     = emulate;
-        this.#speed       = speed;
-        this.#loop        = loop;
-        this.MESSAGE_EVENTS = emulate === 'hid' ? PM5Mock.MESSAGE_EVENTS_HID : PM5Mock.MESSAGE_EVENTS_BLE;
+        this.#speed = speed;
+        this.#loop  = loop;
+
+        if (events || loadEvents) {
+            this.#rawEvents = events ?? null;
+            this.#load = loadEvents;
+        } else {
+            this.#rawEvents = samples ? PM5Mock._toRawEvents(samples, emulate) : null;
+            this.#load = loadSamples ? async () => PM5Mock._toRawEvents(await loadSamples(), emulate) : undefined;
+        }
+        if (this.#rawEvents) this.MESSAGE_EVENTS = [...new Set(this.#rawEvents.map(e => e.type))];
     }
 
     // ── Public API ──────────────────────────────────────────────────
 
     async connect() {
         this.#dispatch('connecting');
-        if (!this.#samples) {
-            this.#samples = await this.#loadSamples();
+        if (!this.#rawEvents) {
+            this.#rawEvents = await this.#load();
+            this.MESSAGE_EVENTS = [...new Set(this.#rawEvents.map(e => e.type))];
         }
         this.#connected = true;
         this.#dispatch('connected', { model: 'Mock', firmwareVersion: '0', serial: 'MOCK' });
@@ -62,36 +68,26 @@ class PM5Mock extends EventTarget {
 
     // ── Replay engine ─────────────────────────────────────────────────
     //
-    // Chained setTimeout honoring real inter-sample gaps (scaled by speed).
-    // The real ergs don't auto-disconnect at the end of a workout, so a
-    // non-looping replay just stops emitting and stays connected.
+    // One chained-setTimeout engine over a flat, already-transport-shaped
+    // raw event list, regardless of source (CSV-derived samples pre-flattened
+    // by `_toRawEvents`, or our own JSON events used as-is). `t` is always
+    // elapsed ms since replay start, so `prevT`'s i=0 baseline of 0 honors
+    // the real gap before the very first event either way. The real ergs
+    // don't auto-disconnect at the end of a workout, so a non-looping replay
+    // just stops emitting and stays connected.
 
     #scheduleNext(i) {
-        if (i >= this.#samples.length) {
+        if (i >= this.#rawEvents.length) {
             if (this.#loop) this.#scheduleNext(0);
             return;
         }
-        const prevT   = i > 0 ? this.#samples[i - 1].t : 0;
-        const delayMs = (this.#samples[i].t - prevT) / this.#speed * 1000;
+        const prevT   = i > 0 ? this.#rawEvents[i - 1].t : 0;
+        const delayMs = (this.#rawEvents[i].t - prevT) / this.#speed;
         this.#timer = setTimeout(() => {
-            this.#emit(this.#samples[i]);
+            const { type, data } = this.#rawEvents[i];
+            this.#dispatch(type, data);
             this.#scheduleNext(i + 1);
         }, Math.max(0, delayMs));
-    }
-
-    #emit(sample) {
-        if (this.#emulate === 'hid') {
-            this.#dispatch('workout', PM5Mock._toHid(sample));
-            return;
-        }
-        // Real BLE hardware demuxes several distinct sub-messages onto the
-        // one 'multiplexed-information' event type, each carrying only its
-        // own fields (see pm5-ble.js _cbGeneralStatus/_cbAdditionalStatus/
-        // _cbAdditionalStrokeData). Mirror that here with narrower dispatches
-        // instead of one event bundling every field.
-        this.#dispatch('multiplexed-information', PM5Mock._toBleGeneralStatus(sample));
-        this.#dispatch('multiplexed-information', PM5Mock._toBleAdditionalStatus(sample));
-        this.#dispatch('multiplexed-information', PM5Mock._toBleAdditionalStrokeData(sample));
     }
 
     #dispatch(type, data = null) {
@@ -100,11 +96,32 @@ class PM5Mock extends EventTarget {
         this.dispatchEvent(event);
     }
 
-    // ── Sample -> event mapping ─────────────────────────────────────────
+    // ── Sample -> raw event synthesis ───────────────────────────────────
     //
     // Pure (no browser APIs), so tests can call these directly. Only keys
     // present in pm5fields are emitted, and undefined sample values are
     // omitted so nothing renders for missing HR/stroke-rate readings.
+
+    // Flattens the reduced sample shape into the same { t, type, data } list
+    // a real transport (or our own JSON export) would produce: `t` in ms
+    // (samples' `t` is elapsed seconds), one 'workout' entry per sample for
+    // HID, three 'multiplexed-information' entries per sample for BLE --
+    // mirroring how real hardware demuxes distinct sub-messages onto that
+    // one event type rather than bundling every field into a single dispatch.
+    static _toRawEvents(samples, emulate) {
+        const events = [];
+        for (const s of samples) {
+            const t = s.t * 1000;
+            if (emulate === 'hid') {
+                events.push({ t, type: 'workout', data: PM5Mock._toHid(s) });
+            } else {
+                events.push({ t, type: 'multiplexed-information', data: PM5Mock._toBleGeneralStatus(s) });
+                events.push({ t, type: 'multiplexed-information', data: PM5Mock._toBleAdditionalStatus(s) });
+                events.push({ t, type: 'multiplexed-information', data: PM5Mock._toBleAdditionalStrokeData(s) });
+            }
+        }
+        return events;
+    }
 
     // Mirrors real general-status: elapsedTime + distance.
     static _toBleGeneralStatus(s) {

--- a/test/events-source.test.mjs
+++ b/test/events-source.test.mjs
@@ -1,0 +1,25 @@
+// Pure-data checks for the JSON mock data source. No hardware, no DOM.
+//   node --test test/events-source.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const { eventsSource } = createRequire(import.meta.url)('../lib/mock-data/events-source.js');
+
+test('parseJson relativizes t so the first event starts at 0', () => {
+    const events = eventsSource.parseJson(JSON.stringify([
+        { t: 1700000000000, type: 'multiplexed-information', data: { elapsedTime: 1 } },
+        { t: 1700000001000, type: 'multiplexed-information', data: { elapsedTime: 2 } },
+    ]));
+    assert.deepEqual(events.map(e => e.t), [0, 1000]);
+    assert.equal(events[0].type, 'multiplexed-information');
+    assert.deepEqual(events[1].data, { elapsedTime: 2 });
+});
+
+test('parseJson passes type/data through untouched', () => {
+    const events = eventsSource.parseJson(JSON.stringify([
+        { t: 5, type: 'workout', data: { workTime: 1, workDistance: 5 } },
+    ]));
+    assert.deepEqual(events[0].data, { workTime: 1, workDistance: 5 });
+    assert.equal(events[0].type, 'workout');
+});

--- a/test/pm5-mock.test.mjs
+++ b/test/pm5-mock.test.mjs
@@ -78,3 +78,67 @@ test('_toHid omits undefined fields and only emits known pm5fields keys', () => 
     });
     for (const k of Object.keys(withHr)) assert.ok(k in pm5fields, `missing key ${k}`);
 });
+
+test('_toRawEvents flattens samples into ble-shaped raw events with t in ms', () => {
+    const samples = [
+        { t: 1, distance: 5, pace: 150, watts: 100, calPerHour: 600, strokeRate: 24, heartRate: 140 },
+        { t: 2, distance: 10, pace: 148, watts: 105, calPerHour: 610, strokeRate: 25, heartRate: 142 },
+    ];
+    const events = PM5Mock._toRawEvents(samples, 'ble');
+
+    assert.equal(events.length, 6); // 3 sub-messages per sample
+    for (const e of events) assert.equal(e.type, 'multiplexed-information');
+    assert.deepEqual(events.map(e => e.t), [1000, 1000, 1000, 2000, 2000, 2000]);
+    assert.deepEqual(events[0].data, PM5Mock._toBleGeneralStatus(samples[0]));
+    assert.deepEqual(events[1].data, PM5Mock._toBleAdditionalStatus(samples[0]));
+    assert.deepEqual(events[2].data, PM5Mock._toBleAdditionalStrokeData(samples[0]));
+});
+
+test('_toRawEvents flattens samples into hid-shaped raw events, one per sample', () => {
+    const samples = [{ t: 1, distance: 5, pace: 150, watts: 100, strokeRate: 24, heartRate: 140 }];
+    const events = PM5Mock._toRawEvents(samples, 'hid');
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, 'workout');
+    assert.equal(events[0].t, 1000);
+    assert.deepEqual(events[0].data, PM5Mock._toHid(samples[0]));
+});
+
+test('PM5Mock replays samples end-to-end (regression: samples/loadSamples path after the raw-event refactor)', async () => {
+    const samples = [
+        { t: 1, distance: 5, pace: 150, watts: 100, calPerHour: 600, strokeRate: 24, heartRate: 140 },
+        { t: 2, distance: 10, pace: 148, watts: 105, calPerHour: 610, strokeRate: 25, heartRate: 142 },
+    ];
+    const monitor = new PM5Mock({ samples, emulate: 'ble', speed: 1000, loop: false });
+    assert.deepEqual(monitor.MESSAGE_EVENTS, ['multiplexed-information']);
+
+    const received = [];
+    for (const type of monitor.MESSAGE_EVENTS) monitor.addEventListener(type, e => received.push(e));
+
+    await monitor.connect();
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    assert.equal(received.length, 6);
+});
+
+test('PM5Mock replays raw `events` verbatim, deriving MESSAGE_EVENTS from what they actually contain', async () => {
+    const events = [
+        { t: 0, type: 'workout', data: { workTime: 1, workDistance: 5 } },
+        { t: 5, type: 'stroke', data: { strokeRate: 24 } },
+        { t: 10, type: 'workout', data: { workTime: 2, workDistance: 10 } },
+    ];
+    const monitor = new PM5Mock({ events, speed: 1000, loop: false });
+    assert.deepEqual(monitor.MESSAGE_EVENTS.sort(), ['stroke', 'workout']);
+
+    const received = [];
+    for (const type of monitor.MESSAGE_EVENTS) monitor.addEventListener(type, e => received.push(e));
+
+    await monitor.connect();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    assert.equal(received.length, 3);
+    assert.deepEqual(received[0].data, events[0].data);
+    assert.equal(received[0].type, 'workout');
+    assert.deepEqual(received[1].data, events[1].data);
+    assert.equal(received[1].type, 'stroke');
+});


### PR DESCRIPTION
Adds a second way into PM5Mock, `events`/`loadEvents`, for our own
full-fidelity JSON export (see ergarcade/recorder's events.js): a flat
[{t, type, data}] list replayed verbatim, no synthesis, since it
already carries the real dispatched type/data -- unlike the existing
`samples`/`loadSamples` path (reduced to 7 fields, synthesized into
BLE/HID-shaped events via `_toBleGeneralStatus` etc since raw samples
carry no transport info of their own).

Unifies both paths behind one chained-setTimeout replay engine over a
flat raw-event list instead of two near-duplicate schedulers: samples
are now pre-flattened into that same shape by a new `_toRawEvents`,
so #scheduleNext just walks one array regardless of source.
MESSAGE_EVENTS is derived from whatever types are actually present in
the loaded data instead of hardcoded from `emulate`, which also
retires the now-dead MESSAGE_EVENTS_BLE/_HID statics.

Adds mock-data/events-source.js (parseJson, mirroring csv-source.js)
and loadFromFile to csv-source.js, for apps to let a user upload
either format instead of only replaying the shipped demo CSV.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
