### PR TITLE
Let Mock replay an uploaded CSV or JSON export, not just the demo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,9 +180,15 @@ matters — no module system):
    (looked up in `pm5fields`, created lazily), skipping keys not in the map.
    Clicking a field row toggles `.highlight`. A `<select id="mock-speed">`
    (hidden unless Mock is selected) sets the initial `speed` when building
-   `PM5Mock` and calls its `setSpeed()`
-   live on change — the one Mock-specific control, since `setSpeed` isn't part
-   of the shared transport interface.
+   `PM5Mock` and calls its `setSpeed()` live on change — the one Mock-specific
+   control, since `setSpeed` isn't part of the shared transport interface.
+   `<input type="file" id="mock-file">` (same visibility rule, disabled while
+   connected like `#transport`) is the other: `TRANSPORTS.mock.build()` reads
+   its selected file and picks `loadEvents` (`.json`, `eventsSource
+   .loadFromFile`) or `loadSamples` (anything else, `csvSource.loadFromFile`)
+   accordingly, falling back to the shipped demo CSV via `loadSamples` when
+   nothing's chosen — so a workout recorded by `ergarcade/recorder` (either
+   export format) can be replayed here.
 
 `example/index.html` also holds an instructions panel implemented as a native
 `<dialog>` (`#instruction-text`), opened via `showModal()`/`close()` — no custom

--- a/example/README.md
+++ b/example/README.md
@@ -35,7 +35,10 @@ then visit `http://localhost:8000/example/`.
 * For Bluetooth/USB: set up a workout on the PM5, start rowing / skiing /
   biking, and watch the numbers change. For Mock, the numbers start climbing
   immediately (real-time by default, looping) — a speed dropdown (1x–16x)
-  appears next to Connect and can be changed live while replaying.
+  appears next to Connect and can be changed live while replaying. A file
+  picker appears alongside it: choose a `.csv` (Concept2 Logbook export) or
+  `.json` (e.g. from `ergarcade/recorder`'s full-fidelity export) to replay
+  that instead of the shipped demo workout.
 * **Split metrics into cards** (checkbox next to Connect): by default, fields
   are grouped into one card per event type, matching how the data actually
   arrives on the wire (e.g. everything BLE reports lands under one

--- a/example/app.js
+++ b/example/app.js
@@ -12,12 +12,15 @@ const TRANSPORTS = {
     usb:       { label: 'USB',       build: () => new PM5HID(), supported: () => !!navigator.hid },
     mock:      {
         label: 'Mock',
-        build: () => new PM5Mock({
-            loadSamples: () => csvSource.loadFromUrl('../lib/mock-data/concept2-result-44214428.csv'),
-            emulate: 'ble',
-            speed: Number(el('#mock-speed').value),
-            loop: true,
-        }),
+        build: () => {
+            const file = el('#mock-file').files[0];
+            const source = !file
+                ? { loadSamples: () => csvSource.loadFromUrl('../lib/mock-data/concept2-result-44214428.csv') }
+                : file.name.endsWith('.json')
+                ? { loadEvents: () => eventsSource.loadFromFile(file) }
+                : { loadSamples: () => csvSource.loadFromFile(file) };
+            return new PM5Mock({ ...source, emulate: 'ble', speed: Number(el('#mock-speed').value), loop: true });
+        },
         supported: () => true,
     },
 };
@@ -42,6 +45,7 @@ const cbConnecting = () => {
     el('#connect').innerText = 'Connecting';
     el('#connect').disabled = true;
     el('#transport').disabled = true;
+    el('#mock-file').disabled = true;
     el('#monitor-information').textContent = 'Please wait...';
 };
 
@@ -65,6 +69,7 @@ const cbDisconnected = () => {
     el('#connect').innerText = 'Connect';
     el('#connect').disabled = false;
     el('#transport').disabled = false;
+    el('#mock-file').disabled = false;
     el('#monitor-information').textContent = '';
     monitor = null;
 };
@@ -129,6 +134,7 @@ const cbMessage = (event) => {
 document.addEventListener('DOMContentLoaded', () => {
     const transportSel = el('#transport');
     const speedSel = el('#mock-speed');
+    const fileSel = el('#mock-file');
 
     // Flag unsupported transports and default to the first supported one.
     let firstSupported = null;
@@ -144,10 +150,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (firstSupported) transportSel.value = firstSupported;
 
-    // The speed control only applies to Mock.
-    const syncSpeedVisibility = () => { speedSel.hidden = transportSel.value !== 'mock'; };
-    syncSpeedVisibility();
-    transportSel.addEventListener('change', syncSpeedVisibility);
+    // The speed control and file picker only apply to Mock.
+    const syncMockControlsVisibility = () => {
+        const isMock = transportSel.value === 'mock';
+        speedSel.hidden = !isMock;
+        fileSel.hidden = !isMock;
+    };
+    syncMockControlsVisibility();
+    transportSel.addEventListener('change', syncMockControlsVisibility);
 
     // Live speed changes take effect immediately if Mock is connected.
     speedSel.addEventListener('change', () => monitor?.setSpeed?.(Number(speedSel.value)));

--- a/example/index.html
+++ b/example/index.html
@@ -9,6 +9,7 @@
         <script src="../lib/pm5-hid.js"></script>
         <script src="../lib/pm5-mock.js"></script>
         <script src="../lib/mock-data/csv-source.js"></script>
+        <script src="../lib/mock-data/events-source.js"></script>
         <script src="../lib/pm5-fields.js"></script>
         <script src="app.js"></script>
 
@@ -31,6 +32,7 @@
                     <option value="8">8x</option>
                     <option value="16">16x</option>
                 </select>
+                <input type="file" id="mock-file" aria-label="Workout file to replay (Concept2 Logbook CSV or our own JSON export)" accept=".csv,.json" hidden>
                 <button id="connect">Connect</button>
                 <label id="split-metrics-label">
                     <input type="checkbox" id="split-metrics">


### PR DESCRIPTION
Same #mock-file picker as ergarcade/recorder and ergarcade/virtual-
monitor, applied to the reference example app: shown/hidden and
enabled/disabled alongside #mock-speed and #transport, Mock-only. A
.json file replays via loadEvents (eventsSource.loadFromFile,
full-fidelity), anything else via loadSamples (csvSource.loadFromFile,
e.g. a Concept2 Logbook CSV), and no selection falls back to the
shipped demo CSV as before.

No submodule bump needed here -- this repo is the source of the
events/loadEvents API being wired up.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
