### PR TITLE
Show BikeErg pace per 1000m instead of misreporting rower/ski units

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,8 +159,30 @@ matters — no module system):
    (`workoutType`, `workoutState`, `strokeState`, `dragFactor`, `heartRate`)
    have a single entry. **`heartRate` is the one reconciled formatter**: BLE
    reports no-belt as 255, HID as 0, so the merged formatter treats both as
-   `N/A` (pinned by the test). A `typeof module` export shim at the end lets
-   the node tests import the maps; it is a no-op in the browser.
+   `N/A` (pinned by the test). **`pace` is the other one with a wrinkle**:
+   the CSAFE spec defines every pace command as seconds/500m unconditionally
+   for every machine type (no bike-specific branch in the protocol), but
+   Concept2's own BikeErg convention displays pace per 1000m, not 500m — a
+   bike covers 500m too fast for that unit to be meaningful. So
+   `pm5printables.pace(secs, ergMachineType)` takes an optional second
+   argument: given a bike `ergMachineType` (192/193/194/207 — see
+   `ergMachineType`'s own enum below), it doubles `secs` and labels the
+   result `/1000m` instead of `/500m`. Every other field's printable ignores
+   a second argument, so callers can pass it unconditionally
+   (`pm5fields[k].printable(v, ergMachineType)`) without special-casing
+   pace. `ergMachineType` is BLE-only and only known for events that happen
+   to carry it — conveniently, BLE's additional-status bundles it alongside
+   `currentPace`/`averagePace` in the very same payload (see
+   `_extractAdditionalStatus` in `pm5-ble.js`), so `event.data.ergMachineType`
+   is right there with no extra state to track; omit it (HID, or any BLE
+   event that doesn't carry it) and `pace` falls back to `/500m`. HID has no
+   equivalent query for machine type at all (`CSAFE_PM_GET_ERGMACHINETYPE`,
+   0xED, isn't in `pm5-hid.js`'s polled command set), so HID's own `pace`
+   field always shows `/500m` — a known gap, not a regression, left as a
+   TODO rather than risking an unverified change to HID's command framing
+   without real hardware to test against. A `typeof module` export shim at
+   the end lets the node tests import the maps; it is a no-op in the
+   browser.
 5. **`example/app.js`** — the only DOM-touching layer, and it is
    **transport-agnostic**. All three classes expose the same interface — public
    `connect()` / `disconnect()` / `connected()`, lifecycle events
@@ -178,6 +200,9 @@ matters — no module system):
    a protocol distinction; toggling it clears `#notifications` so the next
    event rebuilds under the new grouping) and one `.field` row per data key
    (looked up in `pm5fields`, created lazily), skipping keys not in the map.
+   `setField` passes `event.data.ergMachineType` through to every field's
+   `printable` call so pace fields can use it (see `pm5-fields.js` above) —
+   harmless for every other field, which just ignores the extra argument.
    Clicking a field row toggles `.highlight`. A `<select id="mock-speed">`
    (hidden unless Mock is selected) sets the initial `speed` when building
    `PM5Mock` and calls its `setSpeed()` live on change — the one Mock-specific

--- a/example/app.js
+++ b/example/app.js
@@ -91,7 +91,13 @@ const getOrCreateCard = (id, title) => {
     return div;
 };
 
-const setField = (div, k, v) => {
+// `ergMachineType` is only relevant to the pace fields' printable (bike vs
+// rower/ski pace unit); every other field's printable ignores the extra
+// arg. It's undefined unless this event happens to carry it itself --
+// BLE's additional-status bundles ergMachineType alongside currentPace/
+// averagePace in the same payload, so it's simplest to just read it off
+// the same event rather than tracking it as separate running state.
+const setField = (div, k, v, ergMachineType) => {
     let s = div.querySelector(`.field-value.${k}`);
     if (!s) {
         const p = document.createElement('div');
@@ -110,7 +116,7 @@ const setField = (div, k, v) => {
 
         p.addEventListener('click', () => p.classList.toggle('highlight'));
     }
-    s.textContent = pm5fields[k].printable(v);
+    s.textContent = pm5fields[k].printable(v, ergMachineType);
 };
 
 // Two card layouts: grouped by the transport's event type (matches how the
@@ -120,14 +126,14 @@ const cbMessage = (event) => {
     if (el('#split-metrics').checked) {
         for (const [k, v] of Object.entries(event.data)) {
             if (!(k in pm5fields)) continue;
-            setField(getOrCreateCard(`metric-${k}`, pm5fields[k].label), k, v);
+            setField(getOrCreateCard(`metric-${k}`, pm5fields[k].label), k, v, event.data.ergMachineType);
         }
         return;
     }
 
     const div = getOrCreateCard(event.type, formatCardTitle(event.type));
     for (const [k, v] of Object.entries(event.data)) {
-        if (k in pm5fields) setField(div, k, v);
+        if (k in pm5fields) setField(div, k, v, event.data.ergMachineType);
     }
 };
 

--- a/lib/pm5-fields.js
+++ b/lib/pm5-fields.js
@@ -91,11 +91,24 @@ const pm5printables = {
         return new Date(secs * 1000).toISOString().slice(11, 19);
     },
 
-    pace500m(secs) {
+    // The CSAFE spec defines every pace command as seconds/500m,
+    // unconditionally for every machine type ("Pace <-> /500m Pace" in the
+    // Pace Conversions appendix has no machine-type branch) -- that's the
+    // raw value BLE/HID both actually send, bike included. But Concept2's
+    // own BikeErg convention displays pace per 1000m, not 500m (a bike
+    // covers 500m too fast for that unit to be meaningful), so on Bike this
+    // doubles the same raw value and relabels it rather than asking
+    // hardware for a number it doesn't have. `ergMachineType` is only known
+    // on BLE, and only for events that carry it alongside pace (BLE's
+    // additional-status bundles both in one payload) -- omit it (HID, or a
+    // BLE event without it) and this falls back to today's /500m behavior.
+    pace(secs, ergMachineType) {
         if (secs <= 0) return '--:--';
-        const m = Math.floor(secs / 60);
-        const s = Math.floor(secs % 60);
-        return `${m}:${String(s).padStart(2, '0')}/500m`;
+        const isBike = [192, 193, 194, 207].includes(ergMachineType); // see ergMachineType below
+        const t = isBike ? secs * 2 : secs;
+        const m = Math.floor(t / 60);
+        const s = Math.floor(t % 60);
+        return `${m}:${String(s).padStart(2, '0')}/${isBike ? '1000m' : '500m'}`;
     },
 
     deviceStatus(n) {
@@ -233,11 +246,11 @@ const pm5fields = {
     },
     currentPace: {
         label: 'Current Pace',
-        printable: pm5printables.secs2hms,
+        printable: pm5printables.pace,
     },
     averagePace: {
         label: 'Average Pace',
-        printable: pm5printables.secs2hms,
+        printable: pm5printables.pace,
     },
     restDistance: {
         label: 'Rest Distance',
@@ -265,7 +278,7 @@ const pm5fields = {
     },
     splitAveragePace: {
         label: 'Split Average Pace',
-        printable: pm5printables.secs2hms,
+        printable: pm5printables.pace,
     },
     splitAveragePower: {
         label: 'Split Average Power',
@@ -373,7 +386,7 @@ const pm5fields = {
     },
     splitIntervalAveragePace: {
         label: 'Split Interval Average Pace',
-        printable: pm5printables.secs2hms,
+        printable: pm5printables.pace,
     },
     splitIntervalTotalCalories: {
         label: 'Split Interval Total Calories',
@@ -485,7 +498,7 @@ const pm5fields = {
     },
     pace: {
         label: 'Pace',
-        printable: pm5printables.pace500m,
+        printable: pm5printables.pace,
     },
     power: {
         label: 'Power',

--- a/test/printables.test.mjs
+++ b/test/printables.test.mjs
@@ -21,9 +21,29 @@ test('shared enum tables resolve for both transports', () => {
 
 test('HID-unique formatters present', () => {
     assert.equal(pm5printables.deviceStatus(5), 'In Use');
-    assert.equal(pm5printables.pace500m(125), '2:05/500m');
-    assert.equal(pm5printables.pace500m(0), '--:--');
+    assert.equal(pm5printables.pace(125), '2:05/500m');
+    assert.equal(pm5printables.pace(0), '--:--');
     assert.equal(pm5printables.spm(24), '24 spm');
+});
+
+test('pace defaults to /500m when no machine type is given (HID, or a BLE event without ergMachineType)', () => {
+    assert.equal(pm5printables.pace(125), '2:05/500m');
+    assert.equal(pm5printables.pace(125, undefined), '2:05/500m');
+});
+
+test('pace defaults to /500m for a non-bike ergMachineType (e.g. rower, ski)', () => {
+    assert.equal(pm5printables.pace(125, 0), '2:05/500m');   // Static D (rower)
+    assert.equal(pm5printables.pace(125, 128), '2:05/500m'); // Static Ski
+});
+
+test('pace doubles the raw value and switches to /1000m for every bike ergMachineType', () => {
+    for (const bike of [192, 193, 194, 207]) {
+        assert.equal(pm5printables.pace(125, bike), '4:10/1000m');
+    }
+});
+
+test('pace still shows the empty-reading sentinel on a bike', () => {
+    assert.equal(pm5printables.pace(0, 192), '--:--');
 });
 
 test('both transports\' keys are all present in the merged map', () => {


### PR DESCRIPTION
The CSAFE spec defines every pace command as seconds/500m
unconditionally for every machine type -- that's the raw value BLE/
HID both actually send, bike included -- but Concept2's own BikeErg
convention displays pace per 1000m (500m covers too fast on a bike to
be a meaningful unit). The value and the "/500m" label were both wrong
for anyone on a bike.

pm5printables.pace(secs, ergMachineType) takes an optional second
arg: given a bike ergMachineType (192/193/194/207), it doubles secs
and labels the result /1000m instead of /500m. Every other field's
printable ignores a second argument, so callers can pass
ergMachineType unconditionally. Wired into all five pace fields
(currentPace, averagePace, splitAveragePace, splitIntervalAveragePace,
HID's pace) and into example/app.js, which now threads
event.data.ergMachineType through setField -- BLE's additional-status
conveniently bundles ergMachineType alongside currentPace/averagePace
in the same payload, so no extra state tracking is needed there.

HID has no equivalent machine-type query in its polled command set
(CSAFE_PM_GET_ERGMACHINETYPE, 0xED, isn't requested), so HID's pace
still always shows /500m -- a known gap, documented rather than
silently wrong, left alone rather than risking an unverified change to
HID's command framing with no hardware to test against.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
