### PR TITLE
Add shared header info-modal UI, wire into example

### DIFF
--- a/.claude/skills/new-product-repo/SKILL.md
+++ b/.claude/skills/new-product-repo/SKILL.md
@@ -101,4 +101,9 @@ submodule, README` is enough — there's no app code yet to describe.
 
 Tell the user the repo is scaffolded and ready — then the actual app design
 (what it displays, its file layout, tests) is a fresh plan-and-build
-conversation, not a continuation of this checklist.
+conversation, not a continuation of this checklist. When that conversation
+gets to `index.html`, point at `pm5-base/README.md`'s "Shared header UI:
+ui/info-modal.js" section (and `pm5-base/example/` as the reference wiring)
+for the standard header: app name top left, transport controls top right, an
+"i" button next to the title opening a `<dialog id="info-modal">` describing
+the app and how Mock works.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,9 @@ No build step, no package manager, no framework — plain HTML/CSS/JS loaded
 directly by the browser. (This supersedes the separate `../pm5-hid` repo,
 which was the standalone USB-only version.)
 
-The repo is laid out as **library + example**, since `pm5-base` is meant to be
-the reusable foundation for future PM5 apps (distributed as one repo, not via
-npm):
+The repo is laid out as **library + shared UI + example**, since `pm5-base`
+is meant to be the reusable foundation for future PM5 apps (distributed as
+one repo, not via npm):
 
 ```
 lib/                  reusable, DOM-free protocol/data code
@@ -31,7 +31,10 @@ lib/                  reusable, DOM-free protocol/data code
     csv-source.js
     events-source.js
     concept2-result-44214428.csv
-example/               the demo app (all DOM-touching code)
+ui/                    reusable, DOM-touching widgets (the one exception to lib/'s DOM-free rule)
+  info-modal.js
+  info-modal.css
+example/               the demo app (all other DOM-touching code)
   index.html
   app.js
   style.css
@@ -183,7 +186,25 @@ matters — no module system):
    without real hardware to test against. A `typeof module` export shim at
    the end lets the node tests import the maps; it is a no-op in the
    browser.
-5. **`example/app.js`** — the only DOM-touching layer, and it is
+5. **`ui/info-modal.js`/`ui/info-modal.css`** — the one shared DOM-touching
+   piece outside `example/`, since every app built on `pm5-base` wants the
+   same header convention: app name top left, a small round "i" button next
+   to it, transport controls top right. `initInfoModal({ titleSelector,
+   dialogSelector })` inserts the button right after the title (`header h1`
+   by default) and wires it to `dialog.showModal()`, plus a `[data-close]`
+   button and backdrop click to `dialog.close()`. It owns only that wiring —
+   the dialog's actual content (what the app does, how Mock works) stays in
+   each app's own `index.html` as a `<dialog id="info-modal">`, since that
+   text is the one part that legitimately differs per app.
+   `ui/info-modal.css` is self-contained (its own `--pm5-ui-*` custom
+   properties with light/dark defaults) rather than depending on each app's
+   own theme tokens, which differ in name and value across apps — it drops
+   in unchanged regardless. `header h1 + .info-toggle { margin-right: auto
+   }` is what keeps the button snug against the title while still pushing
+   `#controls` to the far right, overriding whatever `justify-content` the
+   app's own header rule uses. Untested — DOM-wired glue, same category as
+   `example/app.js` below.
+6. **`example/app.js`** — the only DOM-touching layer in `example/`, and it is
    **transport-agnostic**. All three classes expose the same interface — public
    `connect()` / `disconnect()` / `connected()`, lifecycle events
    `connecting` / `connected` (data = monitor info) / `disconnected`, and a
@@ -215,12 +236,19 @@ matters — no module system):
    nothing's chosen — so a workout recorded by `ergarcade/recorder` (either
    export format) can be replayed here.
 
-`example/index.html` also holds an instructions panel implemented as a native
-`<dialog>` (`#instruction-text`), opened via `showModal()`/`close()` — no custom
-modal library.
+`example/index.html` also holds the info dialog (`#info-modal`, native
+`<dialog>`) that `ui/info-modal.js` wires up — no custom modal library.
 
 Styling (`example/style.css`) is a single stylesheet using CSS custom
 properties, with a `prefers-color-scheme: dark` override block for dark mode.
+
+### Wiring up the shared header/info-modal in a new app
+
+Load `ui/info-modal.js`/`ui/info-modal.css`, add a `<dialog id="info-modal">`
+with the app's own description + a "how Mock works" paragraph (`example`'s is
+the reference copy), and call `initInfoModal()` from `DOMContentLoaded`. No
+changes to `ui/info-modal.js` needed — it's generic across apps as long as
+the header has an `<h1>` and the page has one `#info-modal` dialog.
 
 ### Adding another transport
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,38 @@ A future sample source (e.g. the Concept2 Logbook API) would be a sibling
 module to `csv-source.js` producing the same reduced-sample shape — no
 changes to `pm5-mock.js` needed either way.
 
+## Shared header UI: `ui/info-modal.js`
+
+Every app built on `pm5-base` uses the same header convention: app name top
+left, a small "i" button next to it opening a `<dialog>` that describes the
+app and how Mock works, transport controls top right. `ui/info-modal.js` and
+`ui/info-modal.css` are the reusable half of that — DOM-touching, unlike the
+rest of `lib/`, so they live in their own directory. Load both, keep your
+dialog's content in your own `index.html`, and wire it up:
+
+```html
+<script src="pm5-base/ui/info-modal.js"></script>
+<link rel="stylesheet" href="pm5-base/ui/info-modal.css">
+```
+
+```html
+<header>
+    <h1>Your App</h1>       <!-- the "i" button is inserted right after this -->
+    <div id="controls">...</div>
+</header>
+
+<dialog id="info-modal">
+    <button data-close aria-label="Close">&times;</button>
+    <p>What your app does, and how Mock works.</p>
+</dialog>
+```
+
+```js
+initInfoModal(); // defaults: titleSelector 'header h1', dialogSelector '#info-modal'
+```
+
+See `example/index.html`/`app.js` for the reference wiring.
+
 ## Setting up a new ergarcade product repo
 
 For a one-off script, copying files out of `lib/` (above) is fine. For a full

--- a/example/app.js
+++ b/example/app.js
@@ -198,10 +198,5 @@ document.addEventListener('DOMContentLoaded', () => {
             .catch((error) => { console.log(error); cbDisconnected(); });
     });
 
-    const instructionDialog = el('#instruction-text');
-    el('#toggle-instructions').addEventListener('click', () => instructionDialog.showModal());
-    el('#close-instructions').addEventListener('click', () => instructionDialog.close());
-    instructionDialog.addEventListener('click', (e) => {
-        if (e.target === instructionDialog) instructionDialog.close();
-    });
+    initInfoModal();
 });

--- a/example/index.html
+++ b/example/index.html
@@ -11,8 +11,10 @@
         <script src="../lib/mock-data/csv-source.js"></script>
         <script src="../lib/mock-data/events-source.js"></script>
         <script src="../lib/pm5-fields.js"></script>
+        <script src="../ui/info-modal.js"></script>
         <script src="app.js"></script>
 
+        <link rel="stylesheet" href="../ui/info-modal.css">
         <link rel="stylesheet" href="style.css">
     </head>
 
@@ -38,14 +40,13 @@
                     <input type="checkbox" id="split-metrics">
                     Split metrics into cards
                 </label>
-                <button id="toggle-instructions" class="secondary">Instructions</button>
                 <span id="monitor-information"></span>
             </div>
         </header>
 
         <main>
-            <dialog id="instruction-text">
-                <button id="close-instructions" class="secondary" aria-label="Close">&times;</button>
+            <dialog id="info-modal">
+                <button data-close aria-label="Close">&times;</button>
 
                 <p>
                 This application connects to a
@@ -74,6 +75,15 @@
                     <li>Click any field to highlight it.</li>
                     <li>Set up a workout on the PM5. Start rowing, skiing, or biking. Watch the numbers change.</li>
                 </ul>
+
+                <h2>Mock</h2>
+                <p>
+                Pick <strong>Mock</strong> to try it without hardware. Choose a replay speed, optionally
+                upload a previously recorded workout (a Concept2 Logbook <code>.csv</code> export, or a
+                <code>.json</code> export from <a target="_blank" href="https://github.com/ergarcade/recorder">recorder</a>),
+                and click <strong>Connect</strong>. Leave the file picker empty to replay a bundled demo
+                workout instead.
+                </p>
                 <p>
                 Tested on Chrome on macOS. <a target="_blank" href="https://github.com/ergarcade/pm5-base">Source on GitHub</a>.
                 </p>

--- a/example/style.css
+++ b/example/style.css
@@ -81,26 +81,13 @@ button {
     font-size: 0.875rem;
     font-weight: 500;
     line-height: 1.5;
+    background: var(--accent);
+    color: #fff;
     transition: background 0.12s, color 0.12s;
 }
 
-button:not(.secondary) {
-    background: var(--accent);
-    color: #fff;
-}
-
-button:not(.secondary):hover {
+button:hover {
     background: var(--accent-hover);
-}
-
-button.secondary {
-    background: transparent;
-    color: var(--text);
-    border: 1px solid var(--border);
-}
-
-button.secondary:hover {
-    background: var(--border);
 }
 
 #transport {
@@ -138,79 +125,6 @@ button.secondary:hover {
 
 main {
     padding: 1.25rem;
-}
-
-/* ── Instructions ── */
-
-#instruction-text {
-    position: fixed;
-    inset: 0;
-    max-width: 34rem;
-    max-height: 80vh;
-    margin: auto;
-    padding: 1.5rem;
-    background: var(--surface);
-    color: var(--text);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
-    line-height: 1.65;
-    opacity: 0;
-    transform: scale(0.96);
-    transition: opacity 0.15s ease-out, transform 0.15s ease-out, overlay 0.15s allow-discrete, display 0.15s allow-discrete;
-}
-
-#instruction-text[open] {
-    opacity: 1;
-    transform: scale(1);
-}
-
-@starting-style {
-    #instruction-text[open] {
-        opacity: 0;
-        transform: scale(0.96);
-    }
-}
-
-#instruction-text::backdrop {
-    background: rgba(0, 0, 0, 0.4);
-    opacity: 0;
-    transition: opacity 0.15s ease-out, overlay 0.15s allow-discrete, display 0.15s allow-discrete;
-}
-
-#instruction-text[open]::backdrop {
-    opacity: 1;
-}
-
-@starting-style {
-    #instruction-text[open]::backdrop {
-        opacity: 0;
-    }
-}
-
-#close-instructions {
-    position: absolute;
-    top: 0.75rem;
-    right: 0.75rem;
-    padding: 0.15rem 0.55rem;
-    font-size: 1.1rem;
-    line-height: 1;
-}
-
-#instruction-text h2 {
-    margin: 1rem 0 0.35rem;
-    font-size: 0.875rem;
-    font-weight: 600;
-}
-
-#instruction-text p,
-#instruction-text li {
-    font-size: 0.875rem;
-    color: var(--text-muted);
-}
-
-#instruction-text ul {
-    padding-left: 1.25rem;
 }
 
 /* ── Notification grid ── */

--- a/ui/info-modal.css
+++ b/ui/info-modal.css
@@ -1,0 +1,125 @@
+/* Self-contained: uses its own --pm5-ui-* tokens rather than each app's
+   theme variables (which use different names/values across apps), so this
+   drops into any header/dialog unchanged. */
+:root {
+    --pm5-ui-surface: #ffffff;
+    --pm5-ui-border:  #d4d4d8;
+    --pm5-ui-text:    #18181b;
+    --pm5-ui-muted:   #71717a;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --pm5-ui-surface: #1c1c1e;
+        --pm5-ui-border:  #3f3f46;
+        --pm5-ui-text:    #f2f2f7;
+        --pm5-ui-muted:   #a1a1aa;
+    }
+}
+
+/* Auto margin (not header's own justify-content) is what keeps this snug
+   against the <h1> while still pushing #controls to the far right,
+   regardless of how each app's header.style.css lays out its flex items. */
+header h1 + .info-toggle {
+    margin-right: auto;
+}
+
+.info-toggle {
+    width: 1.35rem;
+    height: 1.35rem;
+    padding: 0;
+    border: 1px solid var(--pm5-ui-border);
+    border-radius: 50%;
+    background: transparent;
+    color: var(--pm5-ui-muted);
+    font: italic 600 0.8rem/1 Georgia, serif;
+    cursor: pointer;
+}
+
+.info-toggle:hover {
+    color: var(--pm5-ui-text);
+    border-color: var(--pm5-ui-muted);
+}
+
+#info-modal {
+    position: fixed;
+    inset: 0;
+    max-width: 34rem;
+    max-height: 80vh;
+    margin: auto;
+    padding: 1.5rem;
+    background: var(--pm5-ui-surface);
+    color: var(--pm5-ui-text);
+    border: 1px solid var(--pm5-ui-border);
+    border-radius: 0.5rem;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+    line-height: 1.65;
+    opacity: 0;
+    transform: scale(0.96);
+    transition: opacity 0.15s ease-out, transform 0.15s ease-out, overlay 0.15s allow-discrete, display 0.15s allow-discrete;
+}
+
+#info-modal[open] {
+    opacity: 1;
+    transform: scale(1);
+}
+
+@starting-style {
+    #info-modal[open] {
+        opacity: 0;
+        transform: scale(0.96);
+    }
+}
+
+#info-modal::backdrop {
+    background: rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    transition: opacity 0.15s ease-out, overlay 0.15s allow-discrete, display 0.15s allow-discrete;
+}
+
+#info-modal[open]::backdrop {
+    opacity: 1;
+}
+
+@starting-style {
+    #info-modal[open]::backdrop {
+        opacity: 0;
+    }
+}
+
+#info-modal [data-close] {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    border: none;
+    background: transparent;
+    color: var(--pm5-ui-muted);
+    padding: 0.15rem 0.55rem;
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+}
+
+#info-modal [data-close]:hover {
+    color: var(--pm5-ui-text);
+}
+
+#info-modal h2 {
+    margin: 1rem 0 0.35rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+}
+
+#info-modal h2:first-child {
+    margin-top: 0;
+}
+
+#info-modal p,
+#info-modal li {
+    font-size: 0.875rem;
+    color: var(--pm5-ui-muted);
+}
+
+#info-modal ul {
+    padding-left: 1.25rem;
+}

--- a/ui/info-modal.js
+++ b/ui/info-modal.js
@@ -1,0 +1,21 @@
+// Wires up the standard "i" info button next to an app's <h1> and the
+// open/close behavior of its companion <dialog>. The dialog's content is
+// app-specific and stays in that app's own index.html -- this only owns the
+// button + show/close/backdrop-click wiring, so every app doesn't hand-roll
+// the same few lines. DOM-touching by design (unlike lib/, which is DOM-free).
+function initInfoModal({ titleSelector = 'header h1', dialogSelector = '#info-modal' } = {}) {
+    const title = document.querySelector(titleSelector);
+    const dialog = document.querySelector(dialogSelector);
+
+    const button = document.createElement('button');
+    button.id = 'info-toggle';
+    button.className = 'info-toggle';
+    button.type = 'button';
+    button.setAttribute('aria-label', 'About this app');
+    button.textContent = 'i';
+    title.insertAdjacentElement('afterend', button);
+
+    button.addEventListener('click', () => dialog.showModal());
+    dialog.querySelector('[data-close]')?.addEventListener('click', () => dialog.close());
+    dialog.addEventListener('click', (e) => { if (e.target === dialog) dialog.close(); });
+}


### PR DESCRIPTION
Every app built on pm5-base wants the same header convention (title,
info icon + dialog, transport controls) -- ui/info-modal.js/.css is
the reusable half, DOM-touching by design unlike the rest of lib/.
example/ adopts it in place of its old one-off Instructions button.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
