### PR TITLE
Fix HID pace showing bogus sub-second splits from a wrong 0.01 scale factor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,16 @@ matters — no module system):
    Owns the CSAFE-over-USB protocol: builds/sends command frames (byte-stuffing,
    XOR checksum), parses responses, and polls at 100 ms (a stroke frame every
    tick, a full workout frame every 5th tick). Dispatches its data as `workout`
-   and `stroke` events. Also zero DOM dependencies.
+   and `stroke` events. Also zero DOM dependencies. Its `pace` field
+   (`CSAFE_GETPACE_CMD`, 0xA6) needs **no scaling** — the raw u16 is already
+   whole seconds/500m (CSAFE spec Appendix B: pace display resolution is
+   1 sec), unlike BLE's `currentPace`/`averagePace`, which really are a
+   0.01 sec lsb but come from a *different* PM-specific command
+   (`CSAFE_PM_GET_STROKE_500MPACE`, see `pm5-ble.js`). Don't copy that
+   scaling over here again — confirmed against two recorded HID workouts by
+   cross-checking the raw value against `Watts = 2.8/pace³` (pace in
+   sec/meter), which matched 1:1. The conversion lives in the exported
+   `hidPaceSeconds()` helper (pinned by `test/pm5-hid.test.mjs`).
 3. **`lib/pm5-mock.js`** — `PM5Mock`, an `EventTarget` subclass replaying a
    flat, already transport-shaped raw event list — `[{ t, type, data }]`, `t`
    = elapsed ms since replay start — through one chained-`setTimeout` engine

--- a/lib/pm5-hid.js
+++ b/lib/pm5-hid.js
@@ -1,3 +1,14 @@
+// Standard CSAFE_GETPACE_CMD (0xA6) reports Stroke Pace at 1 sec/500m
+// resolution (CSAFE spec Appendix B, "Time and Distance Displayed" -- pace is
+// 1sec resolution, unlike the PM-specific BLE additional-status pace fields,
+// which are a *different* command (CSAFE_PM_GET_STROKE_500MPACE) with a
+// 0.01 sec lsb). No scaling needed here -- confirmed against recorded HID
+// workouts by cross-checking the raw value against Watts = 2.8/pace^3 (pace
+// in sec/meter), which matched 1:1.
+function hidPaceSeconds(raw) {
+    return raw;
+}
+
 class PM5HID extends EventTarget {
 
     // Data-event types app.js subscribes to for this transport.
@@ -219,7 +230,7 @@ class PM5HID extends EventTarget {
             status,
             workTime:     t.length >= 3 ? t[0] * 3600 + t[1] * 60 + t[2] : 0,
             workDistance: u16(get('a1')),          // metres
-            pace:         u16(get('a6')) * 0.01,   // seconds per 500m (0.01 s/500m lsb)
+            pace:         hidPaceSeconds(u16(get('a6'))), // seconds per 500m
             power:        u16(get('b4')),           // watts
             calories:     u16(get('a3')),           // kcal
             cadence:      u16(get('a7')),           // strokes/min
@@ -342,4 +353,10 @@ class PM5HID extends EventTarget {
         event.data   = data;
         this.dispatchEvent(event);
     }
+}
+
+// ponytail: export shim so test/pm5-hid.test.mjs can import the pure pace
+// helper under node; a no-op in the browser (no `module`).
+if (typeof module !== 'undefined') {
+    module.exports = { hidPaceSeconds };
 }

--- a/test/pm5-hid.test.mjs
+++ b/test/pm5-hid.test.mjs
@@ -1,0 +1,13 @@
+// Pure-data checks for the HID pace conversion. No hardware, no DOM.
+//   node --test test/pm5-hid.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const { hidPaceSeconds } = createRequire(import.meta.url)('../lib/pm5-hid.js');
+
+test('hidPaceSeconds passes the raw CSAFE_GETPACE_CMD value through unscaled (1 sec/500m lsb)', () => {
+    assert.equal(hidPaceSeconds(0), 0);
+    assert.equal(hidPaceSeconds(237), 237); // ~3:57/500m, seen in a real recording
+    assert.equal(hidPaceSeconds(90), 90);   // world-record-ish pace, plausible whole-second value
+});


### PR DESCRIPTION
pace copied BLE's 0.01 sec/500m lsb, but HID's CSAFE_GETPACE_CMD is a
different command that's already whole seconds/500m per the CSAFE spec.
Confirmed against two recorded HID workouts via Watts = 2.8/pace^3.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
