### PR TITLE
Add screen wake-lock status icon, keep screensaver off while connected

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,43 @@ matters — no module system):
    `#controls` to the far right, overriding whatever `justify-content` the
    app's own header rule uses. Untested — DOM-wired glue, same category as
    `example/app.js` below.
-6. **`example/app.js`** — the only DOM-touching layer in `example/`, and it is
+6. **`ui/wake-lock.js`** — the other shared `ui/` piece, split into two
+   layers. `initWakeLock(monitor, { nav, doc, onChange })` is the pure wiring:
+   requests a Screen Wake Lock on `monitor`'s `connected` event, releases it
+   on `disconnected`, and also listens for `visibilitychange` to reacquire if
+   still connected when the tab becomes visible again (the browser
+   force-releases the lock whenever the tab is hidden). No-ops (doesn't
+   throw) in browsers without `navigator.wakeLock` (e.g. Firefox, which keeps
+   it behind a flag; Safari has supported it since 16.4) — `onChange`
+   (if given) still fires with `false` so a caller can reflect that state.
+   Unlike `info-modal.js`, this layer touches no DOM elements — only
+   `navigator`/`document` — so it takes them as injectable `{ nav, doc }`
+   options (defaulting to the real globals) and is covered by
+   `test/wake-lock.test.mjs` against a stubbed `EventTarget` monitor and fake
+   `navigator.wakeLock`/`document`. `createWakeLockIndicator({ doc })` is the
+   DOM-*rendering* layer on top: inserts a 🔒/🔓 `<span
+   class="wake-lock-indicator">` right after `#info-toggle` (so it depends
+   on `info-modal.js` having run first) with a native `title` tooltip, and
+   returns the `setActive` updater. It's **idempotent** — reuses the
+   existing `.wake-lock-indicator` if one is already there rather than
+   inserting another — because an app's `monitor` instance gets rebuilt on
+   every Connect click (a fresh `PM5`/`PM5HID`/`PM5Mock`), so the indicator
+   needs to survive being wired up again without leaving stray icons behind
+   (regression covered by `test/wake-lock.test.mjs` against a small fake-DOM
+   stub, unlike `info-modal.js`, which is fully untested since it has no
+   comparable branch to regress). `initWakeLockIndicator(monitor)` is the
+   convenience wrapper: calls `createWakeLockIndicator` then `initWakeLock`
+   with `onChange` wired to `setActive`. Call `createWakeLockIndicator()` on
+   its own once at startup (before any `monitor` exists) so the icon shows
+   its default inactive state immediately on page load, then
+   `initWakeLockIndicator(monitor)` per connection. `ui/wake-lock.css` moves
+   `.info-toggle`'s `margin-right: auto` (see `info-modal.css`) onto the
+   indicator instead via `header h1 + .info-toggle:has(+
+   .wake-lock-indicator)`, so the pair stays snug together next to the
+   `<h1>` while `#controls` still gets pushed to the far right. Apps that
+   only want the lock behavior without the icon can call
+   `initWakeLock(monitor)` directly.
+7. **`example/app.js`** — the only DOM-touching layer in `example/`, and it is
    **transport-agnostic**. All three classes expose the same interface — public
    `connect()` / `disconnect()` / `connected()`, lifecycle events
    `connecting` / `connected` (data = monitor info) / `disconnected`, and a

--- a/README.md
+++ b/README.md
@@ -190,6 +190,53 @@ initInfoModal(); // defaults: titleSelector 'header h1', dialogSelector '#info-m
 
 See `example/index.html`/`app.js` for the reference wiring.
 
+## Keeping the screen awake: `ui/wake-lock.js`
+
+Apps running unattended on an arcade display shouldn't get dimmed or
+screensaved mid-workout. `initWakeLockIndicator(monitor)` requests a [Screen
+Wake Lock] while `monitor` is connected and releases it on disconnect,
+reacquiring automatically if the tab was briefly hidden (the browser
+force-releases the lock whenever the tab isn't visible) and it's still
+connected when it comes back — and inserts a 🔒/🔓 status icon right after
+the info button (`#info-toggle`, from `ui/info-modal.js` — load that first)
+with a native tooltip explaining the current state:
+
+```html
+<script src="pm5-base/ui/info-modal.js"></script>
+<script src="pm5-base/ui/wake-lock.js"></script>
+<link rel="stylesheet" href="pm5-base/ui/info-modal.css">
+<link rel="stylesheet" href="pm5-base/ui/wake-lock.css">
+```
+
+Call `createWakeLockIndicator()` once at startup (no `monitor` yet) so the
+icon shows its default 🔓 state immediately on page load, before the user
+has connected anything:
+
+```js
+document.addEventListener('DOMContentLoaded', () => {
+    createWakeLockIndicator();
+    // ...
+});
+```
+
+Then wire it to each `monitor` instance — safe to call again with a new
+instance (e.g. your app rebuilds `monitor` on every Connect click after a
+Disconnect): `initWakeLockIndicator`/`createWakeLockIndicator` reuse the
+existing icon rather than inserting another one.
+
+```js
+monitor.addEventListener('connected', cbConnected);
+monitor.addEventListener('disconnected', cbDisconnected);
+initWakeLockIndicator(monitor);
+```
+
+No-ops in browsers without the API (e.g. Firefox) rather than throwing — the
+icon just stays 🔓. If you want the lock behavior without the icon, call the
+lower-level `initWakeLock(monitor)` directly instead (no `#info-toggle`
+dependency). See `example/index.html`/`app.js` for the reference wiring.
+
+[Screen Wake Lock]: https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API
+
 ## Setting up a new ergarcade product repo
 
 For a one-off script, copying files out of `lib/` (above) is fine. For a full
@@ -246,7 +293,10 @@ with open('docs/csafe-spec.txt', 'w') as f:
 
 The pure `lib/` modules (field/formatter maps, CSV/JSON parsing, sample
 mapping, and `PM5Mock`'s replay engine itself, driven end-to-end with real
-timers) have node tests, no browser or hardware required:
+timers) have node tests, no browser or hardware required. `ui/wake-lock.js`'s
+connect/disconnect/visibilitychange wiring is also tested this way, against a
+stubbed `navigator`/`document` — `ui/info-modal.js` is the one DOM-*rendering*
+exception, untested since it needs a real browser:
 
 ```
 node --test

--- a/example/app.js
+++ b/example/app.js
@@ -192,6 +192,7 @@ document.addEventListener('DOMContentLoaded', () => {
         monitor.addEventListener('connecting', cbConnecting);
         monitor.addEventListener('connected', cbConnected);
         monitor.addEventListener('disconnected', cbDisconnected);
+        initWakeLockIndicator(monitor);
 
         monitor.connect()
             .then(() => { if (!monitor?.connected()) cbDisconnected(); })  // picker cancelled
@@ -199,4 +200,5 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     initInfoModal();
+    createWakeLockIndicator(); // shows the default (inactive) icon before any monitor exists
 });

--- a/example/index.html
+++ b/example/index.html
@@ -12,9 +12,11 @@
         <script src="../lib/mock-data/events-source.js"></script>
         <script src="../lib/pm5-fields.js"></script>
         <script src="../ui/info-modal.js"></script>
+        <script src="../ui/wake-lock.js"></script>
         <script src="app.js"></script>
 
         <link rel="stylesheet" href="../ui/info-modal.css">
+        <link rel="stylesheet" href="../ui/wake-lock.css">
         <link rel="stylesheet" href="style.css">
     </head>
 

--- a/test/wake-lock.test.mjs
+++ b/test/wake-lock.test.mjs
@@ -1,0 +1,174 @@
+// Pure wiring checks for initWakeLock's connect/disconnect/visibilitychange
+// logic, against a stubbed navigator.wakeLock + document. No real DOM.
+//   node --test test/wake-lock.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const { initWakeLock, createWakeLockIndicator } = createRequire(import.meta.url)('../ui/wake-lock.js');
+
+// EventTarget is a node global; a real PM5/PM5HID/PM5Mock is one too.
+class FakeMonitor extends EventTarget {
+    #connected = false;
+    connected() { return this.#connected; }
+    setConnected(v) { this.#connected = v; }
+}
+
+function fakeNav(supported = true) {
+    if (!supported) return {};
+    const lock = { released: false, release() { this.released = true; } };
+    return {
+        wakeLock: {
+            requests: 0,
+            lock,
+            request() { this.requests++; return Promise.resolve(this.lock); },
+        },
+    };
+}
+
+function fakeDoc() {
+    const target = new EventTarget();
+    return {
+        visibilityState: 'visible',
+        addEventListener: target.addEventListener.bind(target),
+        dispatchEvent: target.dispatchEvent.bind(target),
+        setVisibility(v) { this.visibilityState = v; this.dispatchEvent(new Event('visibilitychange')); },
+    };
+}
+
+// Minimal fake DOM (no jsdom) -- just enough surface for
+// createWakeLockIndicator: an #info-toggle to insert after, plus
+// querySelector/createElement/insertAdjacentElement.
+function fakeDomWithInfoToggle() {
+    const inserted = [];
+    const makeElement = () => ({
+        className: '', textContent: '', title: '',
+        insertAdjacentElement(_pos, el) { inserted.push(el); },
+    });
+    const infoToggle = makeElement();
+    return {
+        createElement: () => makeElement(),
+        querySelector(sel) {
+            if (sel === '#info-toggle') return infoToggle;
+            if (sel === '.wake-lock-indicator') return inserted.find(e => e.className === 'wake-lock-indicator') ?? null;
+            return null;
+        },
+        insertedCount: () => inserted.filter(e => e.className === 'wake-lock-indicator').length,
+    };
+}
+
+test('requests a screen lock on connected', async () => {
+    const monitor = new FakeMonitor();
+    const nav = fakeNav();
+    initWakeLock(monitor, { nav, doc: fakeDoc() });
+
+    monitor.setConnected(true);
+    monitor.dispatchEvent(new Event('connected'));
+    await Promise.resolve(); // let the request() promise settle
+
+    assert.equal(nav.wakeLock.requests, 1);
+});
+
+test('releases the lock on disconnected', async () => {
+    const monitor = new FakeMonitor();
+    const nav = fakeNav();
+    initWakeLock(monitor, { nav, doc: fakeDoc() });
+
+    monitor.setConnected(true);
+    monitor.dispatchEvent(new Event('connected'));
+    await Promise.resolve();
+
+    monitor.setConnected(false);
+    monitor.dispatchEvent(new Event('disconnected'));
+
+    assert.equal(nav.wakeLock.lock.released, true);
+});
+
+test('reacquires on visibilitychange if still connected', async () => {
+    const monitor = new FakeMonitor();
+    const nav = fakeNav();
+    const doc = fakeDoc();
+    initWakeLock(monitor, { nav, doc });
+
+    monitor.setConnected(true);
+    monitor.dispatchEvent(new Event('connected'));
+    await Promise.resolve();
+
+    doc.setVisibility('hidden');
+    doc.setVisibility('visible');
+    await Promise.resolve();
+
+    assert.equal(nav.wakeLock.requests, 2);
+});
+
+test('does not reacquire on visibilitychange if not connected', async () => {
+    const monitor = new FakeMonitor();
+    const nav = fakeNav();
+    const doc = fakeDoc();
+    initWakeLock(monitor, { nav, doc });
+
+    doc.setVisibility('hidden');
+    doc.setVisibility('visible');
+    await Promise.resolve();
+
+    assert.equal(nav.wakeLock.requests, 0);
+});
+
+test('no-ops without throwing when wakeLock is unsupported', async () => {
+    const monitor = new FakeMonitor();
+    initWakeLock(monitor, { nav: fakeNav(false), doc: fakeDoc() });
+
+    monitor.setConnected(true);
+    assert.doesNotThrow(() => monitor.dispatchEvent(new Event('connected')));
+});
+
+test('onChange reports true after acquiring, false after releasing', async () => {
+    const monitor = new FakeMonitor();
+    const nav = fakeNav();
+    const changes = [];
+    initWakeLock(monitor, { nav, doc: fakeDoc(), onChange: (active) => changes.push(active) });
+
+    monitor.setConnected(true);
+    monitor.dispatchEvent(new Event('connected'));
+    await Promise.resolve();
+
+    monitor.setConnected(false);
+    monitor.dispatchEvent(new Event('disconnected'));
+
+    assert.deepEqual(changes, [true, false]);
+});
+
+test('onChange reports false when wakeLock is unsupported', async () => {
+    const monitor = new FakeMonitor();
+    const changes = [];
+    initWakeLock(monitor, { nav: fakeNav(false), doc: fakeDoc(), onChange: (active) => changes.push(active) });
+
+    monitor.setConnected(true);
+    monitor.dispatchEvent(new Event('connected'));
+    await Promise.resolve();
+
+    assert.deepEqual(changes, [false]);
+});
+
+// Regression: initWakeLockIndicator used to be called fresh on every
+// Connect click (a new `monitor` each time) and unconditionally created a
+// new icon, so reconnecting repeatedly left extra stray icons in the DOM.
+test('createWakeLockIndicator reuses the existing icon across repeated calls', () => {
+    const doc = fakeDomWithInfoToggle();
+
+    const setActive1 = createWakeLockIndicator({ doc });
+    const setActive2 = createWakeLockIndicator({ doc });
+
+    assert.equal(doc.insertedCount(), 1);
+
+    setActive2(true);
+    assert.equal(doc.querySelector('.wake-lock-indicator').textContent, '\u{1F512}');
+    setActive1(false);
+    assert.equal(doc.querySelector('.wake-lock-indicator').textContent, '\u{1F513}');
+});
+
+test('createWakeLockIndicator defaults to the inactive icon immediately', () => {
+    const doc = fakeDomWithInfoToggle();
+    createWakeLockIndicator({ doc });
+    assert.equal(doc.querySelector('.wake-lock-indicator').textContent, '\u{1F513}');
+});

--- a/ui/wake-lock.css
+++ b/ui/wake-lock.css
@@ -1,0 +1,19 @@
+/* Depends on ui/info-modal.css already being loaded -- the indicator is
+   always positioned right after #info-toggle (see wake-lock.js), so it
+   reuses info-modal.css's --pm5-ui-* tokens instead of redefining them. */
+
+/* .info-toggle normally gets margin-right: auto (info-modal.css) to push
+   #controls to the far right while staying snug against the <h1>. When the
+   wake-lock indicator follows it, move that auto-margin onto the indicator
+   instead, so the pair stays snug together and whichever is visually last
+   is the one pushing #controls away. */
+header h1 + .info-toggle:has(+ .wake-lock-indicator) {
+    margin-right: 0.35rem;
+}
+
+.wake-lock-indicator {
+    margin-right: auto;
+    font-size: 0.8rem;
+    line-height: 1.35rem;
+    cursor: default;
+}

--- a/ui/wake-lock.js
+++ b/ui/wake-lock.js
@@ -1,0 +1,80 @@
+// Keeps the screen awake for as long as a PM5 is connected (Screen Wake
+// Lock API), so an app running unattended on an arcade display doesn't get
+// dimmed/screensaved mid-workout, plus a status icon next to the info
+// button showing whether the lock is currently held. initWakeLock() itself
+// is DOM/browser-API-touching but not DOM-*rendering*, so its logic is
+// factored to be testable under node with a stubbed navigator/document (see
+// test/wake-lock.test.mjs); createWakeLockIndicator()/initWakeLockIndicator()
+// below layer the actual icon on top and are untested DOM-rendering glue,
+// like info-modal.js.
+function initWakeLock(monitor, { nav = navigator, doc = document, onChange } = {}) {
+    let wakeLock = null;
+
+    const acquire = async () => {
+        if (!nav.wakeLock) { onChange?.(false); return; } // unsupported (e.g. Firefox) -- no-op
+        try {
+            wakeLock = await nav.wakeLock.request('screen');
+            onChange?.(true);
+        } catch (err) {
+            console.log(err); // e.g. tab hidden at request time
+            onChange?.(false);
+        }
+    };
+
+    const release = () => {
+        wakeLock?.release();
+        wakeLock = null;
+        onChange?.(false);
+    };
+
+    monitor.addEventListener('connected', acquire);
+    monitor.addEventListener('disconnected', release);
+
+    // The browser force-releases the lock whenever the tab is hidden; if
+    // we're still connected when it becomes visible again, reacquire it.
+    doc.addEventListener('visibilitychange', () => {
+        if (doc.visibilityState === 'visible' && monitor.connected()) acquire();
+    });
+}
+
+// Creates the status icon (locked/unlocked emoji) right after #info-toggle,
+// with a native `title` tooltip -- no custom tooltip widget needed. Reuses
+// the existing icon if one is already there (a caller may rebuild `monitor`
+// -- e.g. on every Connect click -- and re-wire it; that must not insert a
+// second icon each time), so it's safe to call more than once. Returns the
+// setter so a caller can drive it (e.g. from initWakeLock's `onChange`).
+// Call it once on its own at startup to show the default "inactive" state
+// immediately on page load, before any monitor exists.
+function createWakeLockIndicator({ doc = document } = {}) {
+    let icon = doc.querySelector('.wake-lock-indicator');
+    if (!icon) {
+        icon = doc.createElement('span');
+        icon.className = 'wake-lock-indicator';
+        (doc.querySelector('#info-toggle') ?? doc.querySelector('header h1'))
+            .insertAdjacentElement('afterend', icon);
+    }
+
+    const setActive = (active) => {
+        icon.textContent = active ? '\u{1F512}' : '\u{1F513}'; // 🔒 / 🔓
+        icon.title = active
+            ? 'Screen wake lock active — screensaver disabled while connected'
+            : 'Screen wake lock inactive';
+    };
+    setActive(false);
+    return setActive;
+}
+
+// Convenience: creates/reuses the indicator (see createWakeLockIndicator)
+// and wires it to `monitor` via initWakeLock. Purely visual on top of
+// initWakeLock() above, so it's untested DOM-*rendering* glue, same category
+// as info-modal.js (see wake-lock.css for the layout it depends on).
+function initWakeLockIndicator(monitor, opts = {}) {
+    const setActive = createWakeLockIndicator(opts);
+    initWakeLock(monitor, { ...opts, onChange: setActive });
+}
+
+// ponytail: export shim so test/ can import the pure wiring function under
+// node; a no-op in the browser (no `module`).
+if (typeof module !== 'undefined') {
+    module.exports = { initWakeLock, createWakeLockIndicator, initWakeLockIndicator };
+}


### PR DESCRIPTION
Requests a Screen Wake Lock while a PM5 is connected, releasing on
disconnect and reacquiring if the tab regains visibility while still
connected, plus a 🔒/🔓 icon next to the info button reflecting current
state (idempotent across reconnects — a fresh monitor is built on every
Connect click, so the icon must not be recreated each time).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
