### PR TITLE
Bound BLE gatt.connect() with a timeout to fix stuck reconnects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,7 +329,17 @@ For a full-fidelity source: write a sibling module to
   shift or drop when multiplexed (see the `o`/`p`/`s` offset variables). When
   adding or fixing a field, check both code paths. `force-curve-data` (0x003d)
   is deliberately unhandled — not present on real hardware despite being in the
-  spec.
+  spec. `#openGatt()`'s `device.gatt.connect()` call is wrapped in a 15s
+  `withTimeout()` (module-level pure helper, exported via the same
+  `typeof module` shim as `pm5-hid.js`'s `hidPaceSeconds`, pinned by
+  `test/pm5-ble.test.mjs`) because that promise can hang forever instead of
+  rejecting — seen when the OS Bluetooth stack still holds a bond/link from a
+  previous session (see README.md's "Known issue" note and
+  https://github.com/GoogleChrome/samples/issues/668). Without the timeout,
+  `app.js`'s Connect button gets stuck disabled forever with no recovery
+  short of a page reload; the timeout's error message (shown in
+  `#monitor-information` by `app.js`'s `.catch()`) tells the user to check
+  their OS Bluetooth device list instead.
 - **HID (`pm5-hid.js`)**: CSAFE over HID report ID `0x02` with a 120-byte
   payload. Frames are bounded by `0xf1` (start) / `0xf2` (stop); bytes in
   `0xf0–0xf3` inside the payload are byte-stuffed, and a single XOR checksum byte

--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ monitor.addEventListener('multiplexed-information', e => console.log(e.data));
 await monitor.connect(); // prompts the Bluetooth device picker
 ```
 
+**Known issue: reconnecting after a disconnect can hang.** On some
+laptops/OS Bluetooth stacks (reported on Windows, also seen on macOS),
+connecting over Web Bluetooth causes the OS to register the PM5 as a
+bonded/paired device — a generic "Bluetooth device" entry shows up in your
+OS's Bluetooth settings that wasn't there before. If that bond/link isn't
+fully released, the next `connect()` attempt's `device.gatt.connect()` can
+hang indefinitely rather than failing — a known upstream Chromium behavior,
+see [GoogleChrome/samples#668][gatt-connect-hang]. `pm5-ble.js` bounds this
+with a 15s timeout so the UI recovers with an actionable error instead of
+sticking on "Connecting" forever; the underlying fix is to open your OS
+Bluetooth settings, remove/forget that stray device entry, then reconnect
+from the app.
+
+[gatt-connect-hang]: https://github.com/GoogleChrome/samples/issues/668
+
 ### `PM5HID` — USB (`lib/pm5-hid.js`)
 
 Requires Chrome or Edge (Web HID isn't supported in Firefox/Safari) and the

--- a/example/app.js
+++ b/example/app.js
@@ -196,7 +196,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         monitor.connect()
             .then(() => { if (!monitor?.connected()) cbDisconnected(); })  // picker cancelled
-            .catch((error) => { console.log(error); cbDisconnected(); });
+            .catch((error) => {
+                console.log(error);
+                cbDisconnected();
+                el('#monitor-information').textContent = error.message;
+            });
     });
 
     initInfoModal();

--- a/lib/pm5-ble.js
+++ b/lib/pm5-ble.js
@@ -62,6 +62,19 @@ const characteristics = {
     }
 };
 
+// device.gatt.connect() can hang forever instead of rejecting -- seen when
+// the OS Bluetooth stack still holds a bond/link from a previous session
+// (e.g. a stray "Bluetooth device" left in the OS Bluetooth settings after
+// an earlier disconnect). See https://github.com/GoogleChrome/samples/issues/668
+// and README.md's "Known issue" note. Bounding it turns a stuck "Connecting"
+// UI into an actionable error.
+function withTimeout(promise, ms, message) {
+    return Promise.race([
+        promise,
+        new Promise((_, reject) => setTimeout(() => reject(new Error(message)), ms)),
+    ]);
+}
+
 class PM5 extends EventTarget {
 
     // Data-event types app.js subscribes to for this transport. On real
@@ -172,7 +185,13 @@ class PM5 extends EventTarget {
         };
         this.device.addEventListener('gattserverdisconnected', onGattDisconnect);
 
-        this.server = await device.gatt.connect();
+        this.server = await withTimeout(
+            device.gatt.connect(),
+            15000,
+            "Connection timed out. The PM5 may still be linked to this computer's Bluetooth "
+                + "stack from a previous session -- check your OS Bluetooth device list, remove/"
+                + 'forget any generic "Bluetooth device" entry for the PM5, then try again.'
+        );
     }
 
     disconnect() {
@@ -716,4 +735,10 @@ class PM5 extends EventTarget {
         ]);
         return { serialNumber, hardwareRevision, firmwareRevision, manufacturerName };
     }
+}
+
+// ponytail: export shim so test/pm5-ble.test.mjs can import the pure timeout
+// helper under node; a no-op in the browser (no `module`).
+if (typeof module !== 'undefined') {
+    module.exports = { withTimeout };
 }

--- a/test/pm5-ble.test.mjs
+++ b/test/pm5-ble.test.mjs
@@ -1,0 +1,27 @@
+// Pure test of the gatt.connect() timeout guard. No Bluetooth/DOM needed.
+//   node --test test/pm5-ble.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const { withTimeout } = createRequire(import.meta.url)('../lib/pm5-ble.js');
+
+test('withTimeout resolves with the inner promise value when it settles first', async () => {
+    const result = await withTimeout(Promise.resolve('connected'), 1000, 'too slow');
+    assert.equal(result, 'connected');
+});
+
+test('withTimeout rejects with the given message if the inner promise never settles', async () => {
+    const neverSettles = new Promise(() => {});
+    await assert.rejects(
+        () => withTimeout(neverSettles, 10, 'connection timed out'),
+        { message: 'connection timed out' }
+    );
+});
+
+test('withTimeout propagates the inner promise rejection when it rejects first', async () => {
+    await assert.rejects(
+        () => withTimeout(Promise.reject(new Error('device error')), 1000, 'too slow'),
+        { message: 'device error' }
+    );
+});


### PR DESCRIPTION
device.gatt.connect() can hang forever instead of rejecting when the
OS Bluetooth stack still holds a bond/link from a previous session
(a stray "Bluetooth device" entry left in OS Bluetooth settings after
disconnect) -- see GoogleChrome/samples#668. Without a bound, the
Connect button gets stuck disabled with no recovery short of a page
reload. Wrap the connect in a 15s timeout and surface the resulting
error in the UI so the user gets an actionable message instead of a
silent hang.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
